### PR TITLE
Added property wrapper support

### DIFF
--- a/Resolver/Resolver.xcodeproj/project.pbxproj
+++ b/Resolver/Resolver.xcodeproj/project.pbxproj
@@ -12,6 +12,8 @@
 		4CA30FF51FBB6C8500217883 /* Resolver.h in Headers */ = {isa = PBXBuildFile; fileRef = 4CA30FE71FBB6C8500217883 /* Resolver.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		4CA310011FBB6DFA00217883 /* Resolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CA30FFF1FBB6DFA00217883 /* Resolver.swift */; };
 		4CA310021FBB6DFA00217883 /* ResolverStoryboard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CA310001FBB6DFA00217883 /* ResolverStoryboard.swift */; };
+		8B3F85752322EAB70060B3C5 /* TestApplication.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B3F85742322EAB70060B3C5 /* TestApplication.swift */; };
+		8BB9701E23220E8C008657B7 /* ResolverPropertyWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BB9701D23220E8C008657B7 /* ResolverPropertyWrapper.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -33,6 +35,8 @@
 		4CA30FF41FBB6C8500217883 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		4CA30FFF1FBB6DFA00217883 /* Resolver.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Resolver.swift; sourceTree = "<group>"; };
 		4CA310001FBB6DFA00217883 /* ResolverStoryboard.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ResolverStoryboard.swift; sourceTree = "<group>"; };
+		8B3F85742322EAB70060B3C5 /* TestApplication.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestApplication.swift; sourceTree = "<group>"; };
+		8BB9701D23220E8C008657B7 /* ResolverPropertyWrapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResolverPropertyWrapper.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -86,6 +90,7 @@
 			isa = PBXGroup;
 			children = (
 				4CA30FF21FBB6C8500217883 /* ResolverTests.swift */,
+				8B3F85742322EAB70060B3C5 /* TestApplication.swift */,
 				4CA30FF41FBB6C8500217883 /* Info.plist */,
 			);
 			path = ResolverTests;
@@ -95,6 +100,7 @@
 			isa = PBXGroup;
 			children = (
 				4CA30FFF1FBB6DFA00217883 /* Resolver.swift */,
+				8BB9701D23220E8C008657B7 /* ResolverPropertyWrapper.swift */,
 				4CA310001FBB6DFA00217883 /* ResolverStoryboard.swift */,
 			);
 			name = Sources;
@@ -158,16 +164,17 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0910;
-				LastUpgradeCheck = 0910;
+				LastUpgradeCheck = 1100;
 				ORGANIZATIONNAME = com.hmlong;
 				TargetAttributes = {
 					4CA30FE31FBB6C8500217883 = {
 						CreatedOnToolsVersion = 9.1;
-						LastSwiftMigration = 0910;
+						LastSwiftMigration = 1100;
 						ProvisioningStyle = Automatic;
 					};
 					4CA30FEC1FBB6C8500217883 = {
 						CreatedOnToolsVersion = 9.1;
+						LastSwiftMigration = 1100;
 						ProvisioningStyle = Automatic;
 					};
 				};
@@ -212,6 +219,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				8BB9701E23220E8C008657B7 /* ResolverPropertyWrapper.swift in Sources */,
 				4CA310021FBB6DFA00217883 /* ResolverStoryboard.swift in Sources */,
 				4CA310011FBB6DFA00217883 /* Resolver.swift in Sources */,
 			);
@@ -221,6 +229,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				8B3F85752322EAB70060B3C5 /* TestApplication.swift in Sources */,
 				4CA30FF31FBB6C8500217883 /* ResolverTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -250,6 +259,7 @@
 				CLANG_WARN_BOOL_CONVERSION = YES;
 				CLANG_WARN_COMMA = YES;
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				CLANG_WARN_EMPTY_BODY = YES;
@@ -257,6 +267,7 @@
 				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
 				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
 				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
@@ -310,6 +321,7 @@
 				CLANG_WARN_BOOL_CONVERSION = YES;
 				CLANG_WARN_COMMA = YES;
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				CLANG_WARN_EMPTY_BODY = YES;
@@ -317,6 +329,7 @@
 				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
 				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
 				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
@@ -367,7 +380,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -389,7 +402,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.hmlong.Resolver;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;
@@ -404,7 +417,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.hmlong.ResolverTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -419,7 +432,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.hmlong.ResolverTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;

--- a/Resolver/Resolver.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Resolver/Resolver.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Resolver/ResolverTests/Info.plist
+++ b/Resolver/ResolverTests/Info.plist
@@ -18,5 +18,7 @@
 	<string>1.0</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
+	<key>NSPrincipalClass</key>
+	<string>ResolverTests.TestApplication</string>
 </dict>
 </plist>

--- a/Resolver/ResolverTests/ResolverTests.swift
+++ b/Resolver/ResolverTests/ResolverTests.swift
@@ -7,30 +7,22 @@
 //
 
 import XCTest
-@testable import Resolver
+import Resolver
 
 class ResolverTests: XCTestCase {
     
-    override func setUp() {
-        super.setUp()
-        // Put setup code here. This method is called before the invocation of each test method in the class.
-    }
+    @Resolve
+    private var viewModel: ViewModelType
     
-    override func tearDown() {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
-        super.tearDown()
+    func testResolve() {
+        XCTAssertEqual(viewModel.load(), 5)
     }
-    
-    func testExample() {
-        // This is an example of a functional test case.
-        // Use XCTAssert and related functions to verify your tests produce the correct results.
-    }
-    
-    func testPerformanceExample() {
-        // This is an example of a performance test case.
-        self.measure {
-            // Put the code you want to measure the time of here.
-        }
-    }
-    
+}
+
+struct MyViewModel: ViewModelType {
+    func load() -> Int { 5 }
+}
+
+protocol ViewModelType {
+    func load() -> Int
 }

--- a/Resolver/ResolverTests/TestApplication.swift
+++ b/Resolver/ResolverTests/TestApplication.swift
@@ -1,0 +1,23 @@
+//
+//  TestApplication.swift
+//  ResolverTests
+//
+//  Created by Basem Emara on 2019-09-06.
+//  Copyright © 2019 com.hmlong. All rights reserved.
+//
+
+import XCTest
+import Resolver
+
+/// Principle class run before any tests begin, see Info.plist
+class TestApplication: NSObject {
+    
+    override init() {
+        super.init()
+        
+        // Needed early in test life cycle, even before setUp's
+        Resolver.register {
+            MyViewModel() as ViewModelType
+        }
+    }
+}

--- a/Sources/ResolverPropertyWrapper.swift
+++ b/Sources/ResolverPropertyWrapper.swift
@@ -1,0 +1,34 @@
+//
+// ResolverPropertyWrapper.swift
+//
+// Copyright © 2019 Basem Emara. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+import Foundation
+
+@propertyWrapper
+public struct Resolve<Dependency> {
+    public private(set) var wrappedValue: Dependency
+    
+    public init() {
+        wrappedValue = Resolver.resolve(Dependency.self)
+    }
+}


### PR DESCRIPTION
Thanks for a great, light library 👍

Property wrappers is a beautiful fit for dependency injection 🤯😎

Also upgraded to Xcode 11 and Swift 5, and fixed unit test. Do not merge until Xcode 11 released.. just wanted to get thoughts.

```
struct XYZViewModel {

    @Resolve
    var fetcher: XYZFetching

    @Resolve
    var service: XYZService

    func load() -> Data {
        return fetcher.getData(service)
    }
}
```