### PR TITLE
Add public to registerAllServices() method

### DIFF
--- a/Documentation/Registration.md
+++ b/Documentation/Registration.md
@@ -8,7 +8,7 @@ Add a file named `AppDelegate+Injection.swift` to your project and add the follo
 import Resolver
 
 extension Resolver: ResolverRegistering {
-    static func registerAllServices() {
+    public static func registerAllServices() {
 
     }
 }
@@ -32,7 +32,7 @@ Go to the NetworkServices folder and add a swift file named: `NetworkServices+In
 
 ```
 extension Resolver {
-    static func registerMyNetworkServices() {
+    public static func registerMyNetworkServices() {
 
     }
 }
@@ -44,7 +44,7 @@ Now, go back to your  `AppDelegate+Injection.swift` file and add a reference to 
 
 ```
 extension Resolver: ResolverRegistering {
-    static func registerAllServices() {
+    public static func registerAllServices() {
         registerMyNetworkServices()
     }
 }
@@ -63,7 +63,7 @@ import Resolver
 
 extension Resolver {
 
-    static func registerMyNetworkServices() {
+    public static func registerMyNetworkServices() {
 
         // Register protocols XYZFetching and XYZUpdating and create implementation object
         register { XYZCombinedService() }


### PR DESCRIPTION
Just a small documentation change. Swift gave me this error when compiling:

![image](https://user-images.githubusercontent.com/8505851/70958208-80dd2e80-2046-11ea-9783-7a96aebdaeab.png)

Maybe I'm missing something? I'm guessing the ResolverRegistering protocol changed to public at some point.
