### PR TITLE
overloaded InjectedObject init to include args

### DIFF
--- a/Sources/Resolver/Resolver.swift
+++ b/Sources/Resolver/Resolver.swift
@@ -592,6 +592,9 @@ public struct InjectedObject<Service>: DynamicProperty where Service: Observable
     public init(name: String? = nil, container: Resolver? = nil) {
         self.service = container?.resolve(Service.self, name: name) ?? Resolver.resolve(Service.self, name: name)
     }
+    public init(_ args: Any) {
+        self.service = Resolver.resolve(Service.self, args: args)
+    }
     public var wrappedValue: Service {
         get { return service }
         mutating set { service = newValue }


### PR DESCRIPTION
This allows for putting properties within the swift property wrappers. For example:

`@InjectedObject(ServiceType.type1) var myService: MyService`

If you like this idea, I can overload the other inits for the swift property wrappers.