### PR TITLE
Restore iOS 10 support 

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,7 @@ import PackageDescription
 let package = Package(
     name: "Resolver",
     platforms: [
-        .iOS(.v11),
+        .iOS(.v10),
         .macOS(.v10_14),
         .tvOS(.v13),
         .watchOS(.v6)

--- a/Resolver.podspec
+++ b/Resolver.podspec
@@ -7,7 +7,18 @@ Pod::Spec.new do |s|
   s.author       = "Michael Long"
   s.platform     = :ios, "10.0"
   s.source       = { :git => "https://github.com/hmlongco/Resolver.git", :tag => "#{s.version}" }
-  s.source_files  = "Classes", "Sources/Resolver/*.swift"
+
   s.swift_version = '5.1'
   s.ios.framework  = 'UIKit'
+ 
+ s.default_subspec = ['Core', 'SwiftUI']
+
+ s.subspec 'Core' do |ss|
+    ss.source_files  = "Sources/Resolver/*.swift"
+ end 
+
+ s.subspec 'SwiftUI' do |ss|
+    ss.source_files  = "Sources/Resolver/SwiftUI/*.swift"
+ end
+
 end

--- a/Resolver.podspec
+++ b/Resolver.podspec
@@ -5,7 +5,7 @@ Pod::Spec.new do |s|
   s.homepage     = "https://github.com/hmlongco/Resolver"
   s.license      = "MIT"
   s.author       = "Michael Long"
-  s.platform     = :ios, "11.0"
+  s.platform     = :ios, "10.0"
   s.source       = { :git => "https://github.com/hmlongco/Resolver.git", :tag => "#{s.version}" }
   s.source_files  = "Classes", "Sources/Resolver/*.swift"
   s.swift_version = '5.1'

--- a/Resolver.xcodeproj/project.pbxproj
+++ b/Resolver.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 
 /* Begin PBXBuildFile section */
 		4C9BFB0C2357D98800E6FB80 /* ResolverInjectedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C9BFB0B2357D98800E6FB80 /* ResolverInjectedTests.swift */; };
+		DC2BAC1D23BB630900E771D7 /* Resolver+SwiftUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC2BAC1C23BB630900E771D7 /* Resolver+SwiftUI.swift */; };
 		OBJ_40 /* Resolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_9 /* Resolver.swift */; };
 		OBJ_47 /* Package.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_6 /* Package.swift */; };
 		OBJ_58 /* ResolverBasicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_12 /* ResolverBasicTests.swift */; };
@@ -57,6 +58,7 @@
 
 /* Begin PBXFileReference section */
 		4C9BFB0B2357D98800E6FB80 /* ResolverInjectedTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ResolverInjectedTests.swift; sourceTree = "<group>"; };
+		DC2BAC1C23BB630900E771D7 /* Resolver+SwiftUI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Resolver+SwiftUI.swift"; sourceTree = "<group>"; };
 		OBJ_12 /* ResolverBasicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResolverBasicTests.swift; sourceTree = "<group>"; };
 		OBJ_13 /* ResolverClassTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResolverClassTests.swift; sourceTree = "<group>"; };
 		OBJ_14 /* ResolverContainerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResolverContainerTests.swift; sourceTree = "<group>"; };
@@ -100,6 +102,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		DC2BAC1B23BB62EE00E771D7 /* SwiftUI */ = {
+			isa = PBXGroup;
+			children = (
+				DC2BAC1C23BB630900E771D7 /* Resolver+SwiftUI.swift */,
+			);
+			path = SwiftUI;
+			sourceTree = "<group>";
+		};
 		OBJ_10 /* Tests */ = {
 			isa = PBXGroup;
 			children = (
@@ -165,6 +175,7 @@
 		OBJ_8 /* Resolver */ = {
 			isa = PBXGroup;
 			children = (
+				DC2BAC1B23BB62EE00E771D7 /* SwiftUI */,
 				OBJ_9 /* Resolver.swift */,
 			);
 			name = Resolver;
@@ -257,6 +268,7 @@
 			buildActionMask = 0;
 			files = (
 				OBJ_40 /* Resolver.swift in Sources */,
+				DC2BAC1D23BB630900E771D7 /* Resolver+SwiftUI.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Resolver.xcodeproj/project.pbxproj
+++ b/Resolver.xcodeproj/project.pbxproj
@@ -72,7 +72,7 @@
 		OBJ_29 /* CODE_OF_CONDUCT.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = CODE_OF_CONDUCT.md; sourceTree = "<group>"; };
 		OBJ_30 /* LICENSE */ = {isa = PBXFileReference; lastKnownFileType = text; path = LICENSE; sourceTree = "<group>"; };
 		OBJ_31 /* CHANGELOG */ = {isa = PBXFileReference; lastKnownFileType = text; path = CHANGELOG; sourceTree = "<group>"; };
-		OBJ_32 /* Resolver.podspec */ = {isa = PBXFileReference; lastKnownFileType = text; path = Resolver.podspec; sourceTree = "<group>"; };
+		OBJ_32 /* Resolver.podspec */ = {isa = PBXFileReference; lastKnownFileType = text; path = Resolver.podspec; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
 		OBJ_33 /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		OBJ_34 /* _config.yml */ = {isa = PBXFileReference; lastKnownFileType = text; path = _config.yml; sourceTree = "<group>"; };
 		OBJ_6 /* Package.swift */ = {isa = PBXFileReference; explicitFileType = sourcecode.swift; path = Package.swift; sourceTree = "<group>"; };
@@ -228,7 +228,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftMigration = 9999;
-				LastUpgradeCheck = 9999;
+				LastUpgradeCheck = 1130;
 			};
 			buildConfigurationList = OBJ_2 /* Build configuration list for PBXProject "Resolver" */;
 			compatibilityVersion = "Xcode 3.2";
@@ -306,19 +306,46 @@
 		OBJ_3 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COMBINE_HIDPI_IMAGES = YES;
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				ENABLE_NS_ASSERTIONS = YES;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_OPTIMIZATION_LEVEL = 0;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"$(inherited)",
 					"SWIFT_PACKAGE=1",
 					"DEBUG=1",
 				);
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				MACOSX_DEPLOYMENT_TARGET = 10.14;
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_SWIFT_FLAGS = "-DXcode";
@@ -341,7 +368,7 @@
 				);
 				HEADER_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = Resolver.xcodeproj/Resolver_Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
 				MACOSX_DEPLOYMENT_TARGET = 10.14;
 				MARKETING_VERSION = 1.1.2;
@@ -372,7 +399,7 @@
 				);
 				HEADER_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = Resolver.xcodeproj/Resolver_Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
 				MACOSX_DEPLOYMENT_TARGET = 10.14;
 				MARKETING_VERSION = 1.1.2;
@@ -396,17 +423,43 @@
 		OBJ_4 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COMBINE_HIDPI_IMAGES = YES;
 				COPY_PHASE_STRIP = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_OPTIMIZATION_LEVEL = s;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"$(inherited)",
 					"SWIFT_PACKAGE=1",
 				);
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				MACOSX_DEPLOYMENT_TARGET = 10.14;
 				OTHER_SWIFT_FLAGS = "-DXcode";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -451,15 +504,15 @@
 		OBJ_55 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CLANG_ENABLE_MODULES = YES;
-				EMBEDDED_CONTENT_CONTAINS_SWIFT = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
 				);
 				HEADER_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = Resolver.xcodeproj/ResolverTests_Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @loader_path/../Frameworks @loader_path/Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.14;
 				OTHER_CFLAGS = "$(inherited)";
@@ -477,15 +530,15 @@
 		OBJ_56 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CLANG_ENABLE_MODULES = YES;
-				EMBEDDED_CONTENT_CONTAINS_SWIFT = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
 				);
 				HEADER_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = Resolver.xcodeproj/ResolverTests_Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @loader_path/../Frameworks @loader_path/Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.14;
 				OTHER_CFLAGS = "$(inherited)";

--- a/Resolver.xcodeproj/xcshareddata/xcschemes/Resolver-Package.xcscheme
+++ b/Resolver.xcodeproj/xcshareddata/xcschemes/Resolver-Package.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "9999"
+   LastUpgradeVersion = "1130"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Resolver.xcodeproj/xcshareddata/xcschemes/ResolverTests.xcscheme
+++ b/Resolver.xcodeproj/xcshareddata/xcschemes/ResolverTests.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0930"
+   LastUpgradeVersion = "1130"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -10,22 +10,20 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      codeCoverageEnabled = "YES"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      codeCoverageEnabled = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "4CA30FEC1FBB6C8500217883"
+               BlueprintIdentifier = "Resolver::ResolverTests"
                BuildableName = "ResolverTests.xctest"
                BlueprintName = "ResolverTests"
                ReferencedContainer = "container:Resolver.xcodeproj">
             </BuildableReference>
          </TestableReference>
       </Testables>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -37,8 +35,6 @@
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/Sources/Resolver/Resolver.swift
+++ b/Sources/Resolver/Resolver.swift
@@ -626,29 +626,5 @@ public struct LazyInjected<Service> {
     }
 }
 
-/// Immediate injection property wrapper for SwiftUI ObservableObjects. This wrapper is meant for use in SwiftUI Views and exposes
-/// bindable objects similar to that of SwiftUI @observedObject and @environmentObject.
-///
-/// Dependent service must be of type ObservableObject. Updating object state will trigger view update.
-///
-/// Wrapped dependent service is resolved immediately using Resolver.root upon struct initialization.
-///
-@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
-@propertyWrapper
-public struct InjectedObject<Service>: DynamicProperty where Service: ObservableObject {
-    @ObservedObject private var service: Service
-    public init() {
-        self.service = Resolver.resolve(Service.self)
-    }
-    public init(name: String? = nil, container: Resolver? = nil) {
-        self.service = container?.resolve(Service.self, name: name) ?? Resolver.resolve(Service.self, name: name)
-    }
-    public var wrappedValue: Service {
-        get { return service }
-        mutating set { service = newValue }
-    }
-    public var projectedValue: ObservedObject<Service>.Wrapper {
-        return self.$service
-    }
-}
+
 #endif

--- a/Sources/Resolver/SwiftUI/Resolver+SwiftUI.swift
+++ b/Sources/Resolver/SwiftUI/Resolver+SwiftUI.swift
@@ -1,0 +1,45 @@
+//
+//  Resolver+SwiftUI.swift
+//  Resolver
+//
+//  Created by bfrolicher on 31/12/2019.
+//
+#if os(iOS)
+import UIKit
+import SwiftUI
+#elseif os(macOS) || os(tvOS) || os(watchOS)
+import Foundation
+import SwiftUI
+#else
+import Foundation
+#endif
+
+
+#if swift(>=5.1)
+/// Immediate injection property wrapper for SwiftUI ObservableObjects. This wrapper is meant for use in SwiftUI Views and exposes
+/// bindable objects similar to that of SwiftUI @observedObject and @environmentObject.
+///
+/// Dependent service must be of type ObservableObject. Updating object state will trigger view update.
+///
+/// Wrapped dependent service is resolved immediately using Resolver.root upon struct initialization.
+///
+@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+@propertyWrapper
+public struct InjectedObject<Service>: DynamicProperty where Service: ObservableObject {
+    @ObservedObject private var service: Service
+    public init() {
+        self.service = Resolver.resolve(Service.self)
+    }
+    public init(name: String? = nil, container: Resolver? = nil) {
+        self.service = container?.resolve(Service.self, name: name) ?? Resolver.resolve(Service.self, name: name)
+    }
+    public var wrappedValue: Service {
+        get { return service }
+        mutating set { service = newValue }
+    }
+    public var projectedValue: ObservedObject<Service>.Wrapper {
+        return self.$service
+    }
+}
+
+#endif


### PR DESCRIPTION
This pull request restore iOS 10 compatibility removed in issue #27. 

### Report
Xcode complains about `DynamicProperty` and `ObservedObject` only available with iOS 13 and swift UI framework.
Resolver use these object to offer injection for swift UI ObservableObjects. 
The first solution was to remove iOS 10 compatibility. 

 Although iOS 10 is no longer representative, many developers offer support for this version. 
(Personally 3.6% of my users are on iOS 10).


### To another solution 🚀 

The idea is to separate the core of Resolver from the specific part for Swift UI. 
Pod allows this by using 'subspec'.

This pull request proposes to restore iOS 10 support by separating the swift UI part in a pod submodule. 


### Usage 
With use nothing changes. By default Resolver contains the core as well as the dedicated swift UI part. 

```pod 'Resolver'```

But for users who wish to retain iOS 10 support or do not need swift UI support, simply import 

```pod 'Resolver/Core```


ℹ️ I don't know about Swift Package so I hope someone will have a similar solution. 

This PR also contains a lot of XCode compilation properties 're-enabled'. 