### PR TITLE
Use fatalError message instead of print

### DIFF
--- a/Sources/Resolver/Resolver.swift
+++ b/Sources/Resolver/Resolver.swift
@@ -207,8 +207,7 @@ public final class Resolver {
             let service = registration.scope.resolve(resolver: self, registration: registration, args: args) {
             return service
         }
-        print("RESOLVER: '\(Service.self):\(name ?? "")' not resolved. To disambiguate optionals use resover.optional().")
-        fatalError()
+        fatalError("RESOLVER: '\(Service.self):\(name ?? "")' not resolved. To disambiguate optionals use resover.optional().")
     }
 
     /// Static function calls the root registry to resolve an optional Service type.


### PR DESCRIPTION
Minor detail: It would be nice to have the error message within the `fatalError` so Xcode will pick it up.

so instead of this
![print message](https://user-images.githubusercontent.com/5795552/75450179-9cca4e00-596e-11ea-8490-b9aa0b0a2054.png)

Xcode shows the error message not only in the console log
![fatalError message](https://user-images.githubusercontent.com/5795552/75450193-a5bb1f80-596e-11ea-8095-3424bc1612d9.png)
