### PR TITLE
Mark framework to use application extension safe api only

### DIFF
--- a/Resolver.xcodeproj/project.pbxproj
+++ b/Resolver.xcodeproj/project.pbxproj
@@ -334,6 +334,7 @@
 		OBJ_37 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				ENABLE_TESTABILITY = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -365,6 +366,7 @@
 		OBJ_38 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				ENABLE_TESTABILITY = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",


### PR DESCRIPTION
If you use Carthage and include Resolver in an app extension you get the following warning:

```
ld: warning: linking against a dylib which is not safe for use in application extensions: /xxx/Carthage/Build/iOS/Resolver.framework/Resolver
```

This can be easily fixed by setting `APPLICATION_EXTENSION_API_ONLY`