### PR TITLE
[Add] iOS 10 support for Cocoapods & SPM

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,7 @@ import PackageDescription
 let package = Package(
     name: "Resolver",
     platforms: [
-        .iOS(.v11),
+        .iOS(.v10),
         .macOS(.v10_14),
         .tvOS(.v13),
         .watchOS(.v6)
@@ -16,6 +16,9 @@ let package = Package(
         .library(
             name: "Resolver",
             targets: ["Resolver"]),
+        .library(
+            name: "ResolverSwiftUI",
+            targets: ["ResolverSwiftUI"]),
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
@@ -27,6 +30,11 @@ let package = Package(
         .target(
             name: "Resolver",
             dependencies: []),
+            path: "Sources/Resolver/Main"),
+        .target(
+            name: "ResolverSwiftUI",
+            dependencies: [],
+            path: "Sources/Resolver/SwiftUI"),
         .testTarget(
             name: "ResolverTests",
             dependencies: ["Resolver"]),

--- a/Resolver.podspec
+++ b/Resolver.podspec
@@ -6,10 +6,16 @@ Pod::Spec.new do |s|
   s.license      = "MIT"
   s.author       = "Michael Long"
   s.source       = { :git => "https://github.com/hmlongco/Resolver.git", :tag => "#{s.version}" }
-  s.source_files  = "Classes", "Sources/Resolver/*.swift"
+  s.default_subspec = ['Main', 'SwiftUI']
+  s.subspec 'Main' do |ss|
+     ss.source_files  = "Sources/Resolver/Main/*.swift"
+  end
+  s.subspec 'SwiftUI' do |ss|
+     ss.source_files  = "Sources/Resolver/SwiftUI/*.swift"
+  end
   s.swift_version = '5.1'
 
-  s.ios.deployment_target = "11.0"
+  s.ios.deployment_target = "10.0"
   s.ios.framework  = 'UIKit'
 e
   s.osx.deployment_target = "10.15"

--- a/Resolver.xcodeproj/project.pbxproj
+++ b/Resolver.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 
 /* Begin PBXBuildFile section */
 		4C9BFB0C2357D98800E6FB80 /* ResolverInjectedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C9BFB0B2357D98800E6FB80 /* ResolverInjectedTests.swift */; };
+		C282AE662487A0A500EC013F /* Resolver+SwiftUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = C282AE652487A0A500EC013F /* Resolver+SwiftUI.swift */; };
 		OBJ_40 /* Resolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_9 /* Resolver.swift */; };
 		OBJ_47 /* Package.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_6 /* Package.swift */; };
 		OBJ_58 /* ResolverBasicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_12 /* ResolverBasicTests.swift */; };
@@ -57,6 +58,7 @@
 
 /* Begin PBXFileReference section */
 		4C9BFB0B2357D98800E6FB80 /* ResolverInjectedTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ResolverInjectedTests.swift; sourceTree = "<group>"; };
+		C282AE652487A0A500EC013F /* Resolver+SwiftUI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Resolver+SwiftUI.swift"; sourceTree = "<group>"; };
 		OBJ_12 /* ResolverBasicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResolverBasicTests.swift; sourceTree = "<group>"; };
 		OBJ_13 /* ResolverClassTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResolverClassTests.swift; sourceTree = "<group>"; };
 		OBJ_14 /* ResolverContainerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResolverContainerTests.swift; sourceTree = "<group>"; };
@@ -100,6 +102,22 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		C282AE622487A07100EC013F /* Main */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_9 /* Resolver.swift */,
+			);
+			path = Main;
+			sourceTree = "<group>";
+		};
+		C282AE642487A08200EC013F /* SwiftUI */ = {
+			isa = PBXGroup;
+			children = (
+				C282AE652487A0A500EC013F /* Resolver+SwiftUI.swift */,
+			);
+			path = SwiftUI;
+			sourceTree = "<group>";
+		};
 		OBJ_10 /* Tests */ = {
 			isa = PBXGroup;
 			children = (
@@ -165,7 +183,8 @@
 		OBJ_8 /* Resolver */ = {
 			isa = PBXGroup;
 			children = (
-				OBJ_9 /* Resolver.swift */,
+				C282AE642487A08200EC013F /* SwiftUI */,
+				C282AE622487A07100EC013F /* Main */,
 			);
 			name = Resolver;
 			path = Sources/Resolver;
@@ -257,6 +276,7 @@
 			buildActionMask = 0;
 			files = (
 				OBJ_40 /* Resolver.swift in Sources */,
+				C282AE662487A0A500EC013F /* Resolver+SwiftUI.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -343,7 +363,7 @@
 				);
 				HEADER_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = Resolver.xcodeproj/Resolver_Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
 				MACOSX_DEPLOYMENT_TARGET = 10.14;
 				MARKETING_VERSION = 1.1.2;
@@ -376,7 +396,7 @@
 				);
 				HEADER_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = Resolver.xcodeproj/Resolver_Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
 				MACOSX_DEPLOYMENT_TARGET = 10.14;
 				MARKETING_VERSION = 1.1.2;

--- a/Sources/Resolver/Main/Resolver.swift
+++ b/Sources/Resolver/Main/Resolver.swift
@@ -26,10 +26,8 @@
 
 #if os(iOS)
 import UIKit
-import SwiftUI
 #elseif os(macOS) || os(tvOS) || os(watchOS)
 import Foundation
-import SwiftUI
 #else
 import Foundation
 #endif
@@ -652,32 +650,6 @@ public struct OptionalInjected<Service> {
     public var projectedValue: OptionalInjected<Service> {
         get { return self }
         mutating set { self = newValue }
-    }
-}
-
-/// Immediate injection property wrapper for SwiftUI ObservableObjects. This wrapper is meant for use in SwiftUI Views and exposes
-/// bindable objects similar to that of SwiftUI @observedObject and @environmentObject.
-///
-/// Dependent service must be of type ObservableObject. Updating object state will trigger view update.
-///
-/// Wrapped dependent service is resolved immediately using Resolver.root upon struct initialization.
-///
-@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
-@propertyWrapper
-public struct InjectedObject<Service>: DynamicProperty where Service: ObservableObject {
-    @ObservedObject private var service: Service
-    public init() {
-        self.service = Resolver.resolve(Service.self)
-    }
-    public init(name: String? = nil, container: Resolver? = nil) {
-        self.service = container?.resolve(Service.self, name: name) ?? Resolver.resolve(Service.self, name: name)
-    }
-    public var wrappedValue: Service {
-        get { return service }
-        mutating set { service = newValue }
-    }
-    public var projectedValue: ObservedObject<Service>.Wrapper {
-        return self.$service
     }
 }
 #endif

--- a/Sources/Resolver/SwiftUI/Resolver+SwiftUI.swift
+++ b/Sources/Resolver/SwiftUI/Resolver+SwiftUI.swift
@@ -1,0 +1,44 @@
+//
+//  Resolver+SwiftUI.swift
+//  Resolver
+//
+//  Created by Nguyen Minh Quan on 6/3/20.
+//
+
+#if os(iOS)
+import UIKit
+import SwiftUI
+#elseif os(macOS) || os(tvOS) || os(watchOS)
+import Foundation
+import SwiftUI
+#else
+import Foundation
+#endif
+
+/// Immediate injection property wrapper for SwiftUI ObservableObjects. This wrapper is meant for use in SwiftUI Views and exposes
+/// bindable objects similar to that of SwiftUI @observedObject and @environmentObject.
+///
+/// Dependent service must be of type ObservableObject. Updating object state will trigger view update.
+///
+/// Wrapped dependent service is resolved immediately using Resolver.root upon struct initialization.
+///
+#if swift(>=5.1)
+@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+@propertyWrapper
+public struct InjectedObject<Service>: DynamicProperty where Service: ObservableObject {
+    @ObservedObject private var service: Service
+    public init() {
+        self.service = Resolver.resolve(Service.self)
+    }
+    public init(name: String? = nil, container: Resolver? = nil) {
+        self.service = container?.resolve(Service.self, name: name) ?? Resolver.resolve(Service.self, name: name)
+    }
+    public var wrappedValue: Service {
+        get { return service }
+        mutating set { service = newValue }
+    }
+    public var projectedValue: ObservedObject<Service>.Wrapper {
+        return self.$service
+    }
+}
+#endif


### PR DESCRIPTION
[Add] iOS 10 support for Cocoapods & SPM

Reason: Many company still support iOS 10 users

Solution: 
- Cocoapods: Seperate into 2 subspecs - Main & SwiftUI
- SPM: The default Resolver lib contain only the Resolver.swift, while the ResolverSwiftUI lib will contain Resolver+SwiftUI.swift.

Usage:
For developer who wish to support iOS 10 users
- Cocoapods: pod 'Resolver/Main
- SPM: import only Resolver package. Ignore ResolverSwiftUI package

For those who fancy SwiftUI:
- Cocoapods: pod 'Resolver'
- SPM: import both Resolver & ResolverSwiftUI package

Please discuss further information with me here.
By the way, thanks so much for your superb library.