### PR TITLE
Fixed issue with setting up hierarchical containers with named and unnamed services of the same type

### DIFF
--- a/Sources/Resolver/Resolver.swift
+++ b/Sources/Resolver/Resolver.swift
@@ -257,8 +257,8 @@ public final class Resolver {
     /// the supplied type and name.
     private final func lookup<Service>(_ type: Service.Type, name: String) -> ResolverRegistration<Service>? {
         Resolver.registerServices?()
-        if let container = registrations[ObjectIdentifier(Service.self).hashValue] {
-            return container[name] as? ResolverRegistration<Service>
+        if let container = registrations[ObjectIdentifier(Service.self).hashValue], let registration = container[name] {
+            return registration as? ResolverRegistration<Service>
         }
         if let parent = parent, let registration = parent.lookup(type, name: name) {
             return registration

--- a/Tests/ResolverTests/ResolverContainerTests.swift
+++ b/Tests/ResolverTests/ResolverContainerTests.swift
@@ -91,4 +91,61 @@ class ResolverContainerTests: XCTestCase {
         XCTAssert(r2?.name == "Resolved")
     }
 
+    func testResolverParentOverrideSpecificNamedServices() {
+
+        resolver1 = Resolver()
+        resolver2 = Resolver(parent: resolver1)
+
+        resolver1.register()             { XYZNameService("Unnamed service") }
+        resolver1.register(name: "Name") { XYZNameService("Overriden named service") }
+        resolver2.register(name: "Name") { XYZNameService("Resolved named service") }
+
+        // should find in resolver in which it was defined
+        let r1: XYZNameService? = resolver1.optional()
+        XCTAssertNotNil(r1)
+        XCTAssert(r1?.name == "Unnamed service")
+
+        let r1Named: XYZNameService? = resolver1.optional(name: "Name")
+        XCTAssertNotNil(r1Named)
+        XCTAssert(r1Named?.name == "Overriden named service")
+
+        // should resolve from child container
+        let r2: XYZNameService? = resolver2.optional()
+        XCTAssertNotNil(r2)
+        XCTAssert(r2?.name == "Unnamed service")
+
+        // should find new registration in parent container that overrides child container
+        let r2Named: XYZNameService? = resolver2.optional(name: "Name")
+        XCTAssertNotNil(r2Named)
+        XCTAssert(r2Named?.name == "Resolved named service")
+    }
+
+    func testResolverParentOverrideSpecificUnnamedServices() {
+
+        resolver1 = Resolver()
+        resolver2 = Resolver(parent: resolver1)
+
+        resolver1.register(name: "Name") { XYZNameService("Named service") }
+        resolver1.register()             { XYZNameService("Overriden unnamed service") }
+        resolver2.register()             { XYZNameService("Resolved unnamed service") }
+
+        // should find in resolver in which it was defined
+        let r1: XYZNameService? = resolver1.optional()
+        XCTAssertNotNil(r1)
+        XCTAssert(r1?.name == "Overriden unnamed service")
+
+        let r1Named: XYZNameService? = resolver1.optional(name: "Name")
+        XCTAssertNotNil(r1Named)
+        XCTAssert(r1Named?.name == "Named service")
+
+        // should find new registration in parent container that overrides child container
+        let r2: XYZNameService? = resolver2.optional()
+        XCTAssertNotNil(r2)
+        XCTAssert(r2?.name == "Resolved unnamed service")
+
+        // should resolve from child container
+        let r2Named: XYZNameService? = resolver2.optional(name: "Name")
+        XCTAssertNotNil(r2Named)
+        XCTAssert(r2Named?.name == "Named service")
+    }
 }


### PR DESCRIPTION
In my use of Resolver I've ran into an issue with setting up hierarchical Resolver containers where the root container has named and unnamed services of the same type registered. For example:

```swift
Resolver.root.register() { URLSession(configuration: URLSessionConfiguration.default) }
Resolver.root.register(name: "custom") { URLSession(configuration: URLSessionConfiguration.ephemeral) } 
```

Then I make a child container referencing this root container as its parent and override one of the registrations:

```swift
let resolver = Resolver(parent: Resolver.root)
resolver.register() { URLSession(configuration: URLSessionConfiguration.default, delegate: ..., delegateQueue: ...) }
```

If then there is an attempt to resolve from the child resolver the _named_ service, a fatal error is raised if using the `resolve()` method, or `nil` is returned if using the `optional()` method. As far as I can tell from the documentation this is unintended behavior. 

This PR seeks to correct this issue by forwarding lookups to its parent as appropriate. I've added unit tests to the `ResolverContainerTests` class and all unit tests are passing after this change.