### PR TITLE
Add tvOS deployment target for Cocoapods

### DIFF
--- a/Resolver.podspec
+++ b/Resolver.podspec
@@ -11,7 +11,10 @@ Pod::Spec.new do |s|
 
   s.ios.deployment_target = "11.0"
   s.ios.framework  = 'UIKit'
-e
+
+  s.tvos.deployment_target = "11.0"
+  s.tvos.framework  = 'UIKit'
+
   s.osx.deployment_target = "10.15"
   s.osx.framework  = 'AppKit'
 end


### PR DESCRIPTION
As wished in #52 this PR adds support for integrating this library into tvOS targets using Cocoapods.
I used tvOS 11.0 as deployment target as the library also supports iOS 11.