### PR TITLE
Minor/typos and package OS independence

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,12 +5,6 @@ import PackageDescription
 
 let package = Package(
     name: "Resolver",
-    platforms: [
-        .iOS(.v11),
-        .macOS(.v10_14),
-        .tvOS(.v13),
-        .watchOS(.v6)
-    ],
     products: [
         // Products define the executables and libraries produced by a package, and make them visible to other packages.
         .library(

--- a/Package.swift
+++ b/Package.swift
@@ -6,18 +6,12 @@ import PackageDescription
 let package = Package(
     name: "Resolver",
     products: [
-        // Products define the executables and libraries produced by a package, and make them visible to other packages.
         .library(
             name: "Resolver",
             targets: ["Resolver"]),
     ],
-    dependencies: [
-        // Dependencies declare other packages that this package depends on.
-        // .package(url: /* package url */, from: "1.0.0"),
-    ],
+    dependencies: [],
     targets: [
-        // Targets are the basic building blocks of a package. A target can define a module or a test suite.
-        // Targets can depend on other targets in this package, and on products in packages which this package depends on.
         .target(
             name: "Resolver",
             dependencies: []),

--- a/Resolver/ResolverTests/ResolverBasicTests.swift
+++ b/Resolver/ResolverTests/ResolverBasicTests.swift
@@ -30,7 +30,7 @@ class ResolverBasicTests: XCTestCase {
 
     func testRegistrationAndInferedResolution() {
         resolver.register { XYZSessionService() }
-        let session: XYZSessionService? = resolver.resolve() as XYZSessionService
+        let session: XYZSessionService? = resolver.resolve() as? XYZSessionService
         XCTAssertNotNil(session)
     }
 

--- a/Sources/Resolver/Resolver.swift
+++ b/Sources/Resolver/Resolver.swift
@@ -219,7 +219,7 @@ public final class Resolver {
             let service = registration.scope.resolve(resolver: self, registration: registration, args: args) {
             return service
         }
-        fatalError("RESOLVER: '\(Service.self):\(name ?? "")' not resolved. To disambiguate optionals use resover.optional().")
+        fatalError("RESOLVER: '\(Service.self):\(name ?? "")' not resolved. Did you register \(name ?? "")?. Or to disambiguate optionals use resolver.optional().")
     }
 
     /// Static function calls the root registry to resolve an optional Service type.


### PR DESCRIPTION
As the code works perfectly on other OS's thanks to the good pre processor check in the code there is no reason in my opinion for the `Package.swift` to contain code that has states in only works on Apple related platforms