### PR TITLE
Experiment: Passing arguments via propertywrapper @Injected and allowing multiple registries with our without arguments

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,12 +5,6 @@ import PackageDescription
 
 let package = Package(
     name: "Resolver",
-    platforms: [
-        .iOS(.v11),
-        .macOS(.v10_14),
-        .tvOS(.v13),
-        .watchOS(.v6)
-    ],
     products: [
         // Products define the executables and libraries produced by a package, and make them visible to other packages.
         .library(

--- a/Package.swift
+++ b/Package.swift
@@ -6,18 +6,12 @@ import PackageDescription
 let package = Package(
     name: "Resolver",
     products: [
-        // Products define the executables and libraries produced by a package, and make them visible to other packages.
         .library(
             name: "Resolver",
             targets: ["Resolver"]),
     ],
-    dependencies: [
-        // Dependencies declare other packages that this package depends on.
-        // .package(url: /* package url */, from: "1.0.0"),
-    ],
+    dependencies: [],
     targets: [
-        // Targets are the basic building blocks of a package. A target can define a module or a test suite.
-        // Targets can depend on other targets in this package, and on products in packages which this package depends on.
         .target(
             name: "Resolver",
             dependencies: []),

--- a/Resolver/ResolverTests/ResolverBasicTests.swift
+++ b/Resolver/ResolverTests/ResolverBasicTests.swift
@@ -30,7 +30,7 @@ class ResolverBasicTests: XCTestCase {
 
     func testRegistrationAndInferedResolution() {
         resolver.register { XYZSessionService() }
-        let session: XYZSessionService? = resolver.resolve() as XYZSessionService
+        let session: XYZSessionService? = resolver.resolve() as? XYZSessionService
         XCTAssertNotNil(session)
     }
 

--- a/Sources/Resolver/Resolver.swift
+++ b/Sources/Resolver/Resolver.swift
@@ -701,9 +701,56 @@ public struct Injected<Service> {
     public init() {
         self.service = Resolver.resolve(Service.self)
     }
+    
+    /// Will pass data to the factory to resolve instance
+    /// - Parameters:
+    ///   - data: data to be used to initiate the object
+    ///   - name: required when you register for both type with and without arguments. By default ` \(Service.self)DataArgument` is used. Register with the same name.
+    public init(data: Data, name: String = "\(Service.self)DataArgument") {
+        self.service = Resolver.resolve(Service.self, name: name, args: data)
+    }
+    
+    /// Will pass arguments to factory to resolve instance
+    ///
+    /// # discussion
+    ///
+    /// You could extend Injected to allow type safe arguments to be passed
+    ///
+    /// ```swift
+    ///
+    /// extension Injected {
+    ///    init(foo: Foo) {
+    ///        self.init(arguments: foo)
+    ///    }
+    /// }
+    /// ```
+    ///
+    ///  Registration should then include the name parameter
+    ///
+    ///  ```swift
+    ///  Resolver.register(Foo.self, name: "\(Foo.self)Arguments") { (resolver, arguments) in
+    ///    do {
+    ///       guard let foo = arguments as? Foo else {
+    ///          throw "arguments should be of type Foo"
+    ///       }
+    ///
+    ///       return foo
+    ///    } catch {
+    ///       fatalError("\(error)")
+    ///    }
+    ///  }
+    ///  ```
+    /// - Parameters:
+    ///   - arguments: arguments to be passed to factory
+    ///   - name: required when you register for both type with and without arguments. By default ` \(Service.self)Arguments` is used. Register with the same name.
+    public init(arguments: Any?, name: String = "\(Service.self)Arguments") {
+        self.service = Resolver.resolve(Service.self, name: name, args: arguments)
+    }
+    
     public init(name: String? = nil, container: Resolver? = nil) {
         self.service = container?.resolve(Service.self, name: name) ?? Resolver.resolve(Service.self, name: name)
     }
+    
     public var wrappedValue: Service {
         get { return service }
         mutating set { service = newValue }

--- a/Sources/Resolver/Resolver.swift
+++ b/Sources/Resolver/Resolver.swift
@@ -219,7 +219,7 @@ public final class Resolver {
             let service = registration.scope.resolve(resolver: self, registration: registration, args: args) {
             return service
         }
-        fatalError("RESOLVER: '\(Service.self):\(name ?? "")' not resolved. To disambiguate optionals use resover.optional().")
+        fatalError("RESOLVER: '\(Service.self):\(name ?? "")' not resolved. Did you register \(name ?? "")?. Or to disambiguate optionals use resolver.optional().")
     }
 
     /// Static function calls the root registry to resolve an optional Service type.


### PR DESCRIPTION
This relates to #45 where passing arguments is discussed, I learned after reading it that there are valid arguments to not do it and that they are discussed very well in [Resolver Arguments](https://github.com/hmlongco/Resolver/blob/develop/Documentation/Arguments.md) but I would like to add my thoughts to the debate.

The first 3 commits are also handled in pull request #57  and can be ignored here.

# What did I try to solve

* Passing arguments to @Injected
* Explaining the use via Unit tests
* Suggesting to add specific inits to implementing projects to allow a more type safe injection of parameters
* Allow @Injected to pass arguments or not

# My draft solution

* use (or abuse) the name parameter to distinguish between @Injected(args) and @Injected without arguments.
* allow data to be injected. (I later read in #45 that this is maybe a code smell and if so I can remove it)
