### PR TITLE
Extra tests to show behaviour of protocols and @Injected

### DIFF
--- a/Tests/ResolverTests/ResolverInjectedTests.swift
+++ b/Tests/ResolverTests/ResolverInjectedTests.swift
@@ -50,6 +50,15 @@ class OptionalInjectedViewController {
 class NotRegistered {
 }
 
+class UniqueInjectedViewController {
+    
+    class NetworkServiceSingleton {
+        
+    }
+    
+    @Injected var service: NetworkServiceSingleton
+}
+
 class ResolverInjectedTests: XCTestCase {
 
     override func setUp() {
@@ -116,6 +125,69 @@ class ResolverInjectedTests: XCTestCase {
         let vc = OptionalInjectedViewController()
         XCTAssertNotNil(vc.service)
         XCTAssertNil(vc.notRegistered)
+    }
+    
+    func testApplitionInjected_singletons() {
+        
+        Resolver.defaultScope = Resolver.application
+        Resolver.main = Resolver()
+        
+        // Not changing default behaviour
+        Resolver.register {
+            UniqueInjectedViewController.NetworkServiceSingleton()
+        }
+                
+        let s1: UniqueInjectedViewController.NetworkServiceSingleton = Resolver.resolve()
+        let s2: UniqueInjectedViewController.NetworkServiceSingleton = Resolver.resolve()
+        
+        XCTAssertTrue(s1 === s2)
+    
+        let vc1 = UniqueInjectedViewController()
+        let vc2 = UniqueInjectedViewController()
+        
+        XCTAssertTrue(vc1.service === vc2.service)
+    }
+    
+    func testGraphInjected_nosignletons() {
+        
+        Resolver.defaultScope = Resolver.graph
+        Resolver.main = Resolver()
+        
+        // Not changing default behaviour
+        Resolver.register {
+            UniqueInjectedViewController.NetworkServiceSingleton()
+        }
+        
+        let s1: UniqueInjectedViewController.NetworkServiceSingleton = Resolver.resolve()
+        let s2: UniqueInjectedViewController.NetworkServiceSingleton = Resolver.resolve()
+        
+        XCTAssertTrue(s1 !== s2)
+        
+        let vc1 = UniqueInjectedViewController()
+        let vc2 = UniqueInjectedViewController()
+        
+        XCTAssertTrue(vc1.service !== vc2.service)
+    }
+    
+    func testCachedInjected_signletons() {
+        
+        Resolver.defaultScope = Resolver.cached
+        Resolver.main = Resolver()
+        
+        // Not changing default behaviour
+        Resolver.register {
+            UniqueInjectedViewController.NetworkServiceSingleton()
+        }
+        
+        let s1: UniqueInjectedViewController.NetworkServiceSingleton = Resolver.resolve()
+        let s2: UniqueInjectedViewController.NetworkServiceSingleton = Resolver.resolve()
+        
+        XCTAssertTrue(s1 === s2)
+        
+        let vc1 = UniqueInjectedViewController()
+        let vc2 = UniqueInjectedViewController()
+        
+        XCTAssertTrue(vc1.service === vc2.service)
     }
 }
 


### PR DESCRIPTION
There is a bit of a confusing thing as you write tests and use @Injected or register a protocol. I noticed 2 things after reading the comment #55 that might be causing the confusion

1. static Resolver for some reason uses a root and a main resolver. For registering main is used and for resolving root is used. Both are instantiated from `Resolver.main`. When you change the defaultScope both root and main need to be changed
2. For me at least it was not apparent how the @Injected parameters with a protocol worked and how I could avoid in tests using a singleton.

Both should be more clear from the test examples. What do you think?