### PR TITLE
Simplify registry of Services and initial setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,31 @@
 
 An ultralight Dependency Injection / Service Locator framework for Swift 5.2 on iOS.
 
+```swift
+protocol Identifiable {
+    var identifier: String
+}
+class User: Identifiable {
+    var identifier: String
+}
+
+class ViewModel {
+    @Injected var user: User // can be private/public or simply internal
+}
+
+class AppDelegate {
+    init() {
+        Resolver.defaultScope = Resolver.application // will make sure everything is a signleton as long as application runs
+        Resolver.registerServices = {
+            Resolver.register { User(identifier: "itsMe") } // singleton will be used everywhere you add @Injected to a type User
+        }
+    }
+}
+
+```
+
+The above code will share an instance of the `User` that is a signleton. So the code `print(ViewModel().user.identifier)` would print 'itsMe' everwhere it is `@Injected`.
+
 ## Introduction
 
 Dependency Injection frameworks support the [Inversion of Control](https://en.wikipedia.org/wiki/Inversion_of_control) design pattern. Technical definitions aside, dependency injection pretty much boils down to:

--- a/Sources/Resolver/Resolver.swift
+++ b/Sources/Resolver/Resolver.swift
@@ -36,10 +36,6 @@ import Foundation
 
 // swiftlint:disable file_length
 
-public protocol ResolverRegistering {
-    static func registerAllServices()
-}
-
 /// The Resolving protocol is used to make the Resolver registries available to a given class.
 public protocol Resolving {
     var resolver: Resolver { get }
@@ -76,14 +72,13 @@ public final class Resolver {
     }
 
     /// Called by the Resolution functions to perform one-time initialization of the Resolver registries.
+    /// You should sett this if you want your services to be call register once on startup.
     public static var registerServices: (() -> Void)? = registerServicesBlock
 
     private static var registerServicesBlock: (() -> Void) = { () in
         pthread_mutex_lock(&Resolver.registrationMutex)
         defer { pthread_mutex_unlock(&Resolver.registrationMutex) }
-        if Resolver.registerServices != nil, let registering = (Resolver.root as Any) as? ResolverRegistering {
-            type(of: registering).registerAllServices()
-        }
+        Resolver.registerServices?()
         Resolver.registerServices = nil
     }
 

--- a/Tests/ResolverTests/ResolverArgumentTests.swift
+++ b/Tests/ResolverTests/ResolverArgumentTests.swift
@@ -15,6 +15,11 @@ class ResolverArgumentTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
+        Resolver.registerServices = {
+            Resolver.register { XYZSessionService() }
+            Resolver.register { XYZService( Resolver.optional() ) }
+        }
+
         resolver = Resolver()
     }
     

--- a/Tests/ResolverTests/TestData.swift
+++ b/Tests/ResolverTests/TestData.swift
@@ -9,13 +9,6 @@
 import Foundation
 import Resolver
 
-extension Resolver: ResolverRegistering {
-    public static func registerAllServices() {
-        register { XYZSessionService() }
-        register { XYZService( optional() ) }
-    }
-}
-
 class XYZViewModel {
 
     var editMode = true


### PR DESCRIPTION
As I am new to the topic it but not to Injection, I used Swinject before (to complex), I was looking for a simple approach using property wrappers. This repo seams to fit that bill but it took me some time to figure out how to set it up. There is also a question about an example project #5. 

I found out that there seams to be some code that looks too complex to me that you would need to get a HelloWorld kind of setup. That is the registerAllServices. This seamed to me too complex so I propose a change. It might be that I miss a reasoning behind this being so complex with type casting and all but then let me know.

Further I added some code that should get new users fast to a HelloWorld experience. Is this more clear to you to?