### PR TITLE
Add WeakInjected and LazyWeakInjected

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,10 @@
 # Resolver Changelog
 
+### 1.1.5
+
+* Add WeakInjected function to inject with a weak reference
+* Add LazyWeakInjected function to inject with a weak reference
+
 ### 1.1.4
 
 * Add Resolver.reset() function to reset Resolver to original state

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -8,19 +8,19 @@ In the interest of fostering an open and welcoming environment, we as contributo
 
 Examples of behavior that contributes to creating a positive environment include:
 
-* Using welcoming and inclusive language
-* Being respectful of differing viewpoints and experiences
-* Gracefully accepting constructive criticism
-* Focusing on what is best for the community
-* Showing empathy towards other community members
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+- Gracefully accepting constructive criticism
+- Focusing on what is best for the community
+- Showing empathy towards other community members
 
 Examples of unacceptable behavior by participants include:
 
-* The use of sexualized language or imagery and unwelcome sexual attention or advances
-* Trolling, insulting/derogatory comments, and personal or political attacks
-* Public or private harassment
-* Publishing others' private information, such as a physical or electronic address, without explicit permission
-* Other conduct which could reasonably be considered inappropriate in a professional setting
+- The use of sexualized language or imagery and unwelcome sexual attention or advances
+- Trolling, insulting/derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or electronic address, without explicit permission
+- Other conduct which could reasonably be considered inappropriate in a professional setting
 
 ## Our Responsibilities
 

--- a/Documentation/Annotation.md
+++ b/Documentation/Annotation.md
@@ -37,6 +37,39 @@ class NamedInjectedViewController: UIViewController {
 
 Note that LazyInjected is a mutating property wrapper. As such it can only be used in class instances or in structs when the struct is mutable.
 
+### Weak Injection and LazyWeakInjection
+
+Resolver also has a WeakInjected property wrapper. Unlike using Injected, weak injected service are not stored into the target object using a strong reference.
+
+```swift
+class NamedInjectedViewController: UIViewController {
+    // service won't create a retain cycle
+    @LazyWeakInjected var service: XYZNameService?
+    func load() {
+        service?.load()
+    }
+}
+```
+
+Moreover, Resolver also has a LazyWeakInjected property wrapper, which combine WeakInjected and LazyInjected.
+Unlike using Injected, lazily weak, injected services are not resolved until the code attempts to access the wrapped service and are not stored into the target object using a strong reference.
+
+```swift
+class NamedInjectedViewController: UIViewController {
+    @Injected var presenter: NamedInjectedPresenter?
+    func load() {
+        service.load() // service will be resolved at this point in time
+    }
+}
+
+class NamedInjectedPresenter {
+    // viewController won't create a retain cycle
+    @LazyWeakInjected var viewController: NamedInjectedViewController?
+}
+```
+
+Note that LazyInjected is a mutating property wrapper. As such it can only be used in class instances or in structs when the struct is mutable.
+
 ### Named injection
 
 You can use named service resolution using the `name` property wrapper initializer as shown below.

--- a/Documentation/Annotation.md
+++ b/Documentation/Annotation.md
@@ -1,4 +1,4 @@
-#  Resolver: Annotation
+# Resolver: Annotation
 
 Another common Dependency Injection strategy is annotation: adding comments or other metadata to the code which indicates that the following service needs to be resolved by the dependency injection system.
 
@@ -13,6 +13,7 @@ class BasicInjectedViewController: UIViewController {
     @Injected var service: XYZService
 }
 ```
+
 Just add the Injected property wrapper and your dependencies will be resolved automatically and instantiated immediately, ready and waiting for use.
 
 **Note that you still need to [register](Registration.md) any class or classes that you need to resolve.**
@@ -21,10 +22,11 @@ Also note that as long as you compile with Swift 5.1, **property wrappers work o
 
 The Injected property wrapper will automatically instantiate objects using the current Resolver root container, exactly as if you'd done `var service: XYZService = Resolver.resolve()`. See instructions below on how to specify a different container.
 
-###  Lazy Injection
+### Lazy Injection
 
 Resolver also has a LazyInjected property wrapper. Unlike using Injected, lazily injected services are not resolved until the code attempts to access the wrapped service.
-```
+
+```swift
 class NamedInjectedViewController: UIViewController {
     @LazyInjected var service: XYZNameService
     func load() {
@@ -32,19 +34,22 @@ class NamedInjectedViewController: UIViewController {
     }
 }
 ```
+
 Note that LazyInjected is a mutating property wrapper. As such it can only be used in class instances or in structs when the struct is mutable.
 
 ### Named injection
 
-You can use named service resolution using the `name`  property wrapper initializer as shown below.
+You can use named service resolution using the `name` property wrapper initializer as shown below.
 
-```
+```swift
 class NamedInjectedViewController: UIViewController {
     @Injected(name: "fred") var service: XYZNameService
 }
 ```
+
 You can also update the name in code and 'on the fly' using @LazyInjected.
-```
+
+```swift
 class NamedInjectedViewController: UIViewController {
     @LazyInjected var service: XYZNameService
     var which: Bool
@@ -54,12 +59,14 @@ class NamedInjectedViewController: UIViewController {
     }
 }
 ```
-If you go this route just make sure you specify the name *before* accessing the injected service for the first time.
 
-###  Optional injection
+If you go this route just make sure you specify the name _before_ accessing the injected service for the first time.
+
+### Optional injection
 
 An annotation is available that supports optional resolving. If the service is not registered, then the value will be nil, otherwise it will be not nil:
-```
+
+```swift
 class InjectedViewController: UIViewController {
     @OptionalInjected var service: XYZService?
     func load() {
@@ -72,19 +79,23 @@ class InjectedViewController: UIViewController {
 
 You can specify and resolve custom containers using Injected. Just define your custom container...
 
-```
+```swift
 extension Resolver {
     static var custom = Resolver()
 }
 ```
+
 And specify it as part of the Injected property wrapper initializer.
-```
+
+```swift
 class ContainerInjectedViewController: UIViewController {
     @Injected(container: .custom) var service: XYZNameService
 }
 ```
+
 As with named injection, with LazyInjected you can also dynamically specifiy the desired container.
-```
+
+```swift
 class NamedInjectedViewController: UIViewController {
     @LazyInjected var service: XYZNameService
     var which: Bool

--- a/Documentation/Arguments.md
+++ b/Documentation/Arguments.md
@@ -1,4 +1,4 @@
-#  Resolver: Arguments
+# Resolver: Arguments
 
 ## Passing arguments to a registration factory
 

--- a/Documentation/Cycle.md
+++ b/Documentation/Cycle.md
@@ -65,4 +65,4 @@ MyViewController doesn't know the internals of XYZViewModel, nor does it know ab
 
 Nor does it need to. It simply asks Resolver for an instance of type T, and Resolver complies.
 
-This chain of events is known as a *Resolution Cycle*.
+This chain of events is known as a _Resolution Cycle_.

--- a/Documentation/CyclicDependencies.md
+++ b/Documentation/CyclicDependencies.md
@@ -100,7 +100,9 @@ register { ClassC() }
 
 The parent class has a reference to its child, and the child obtains a reference back to its shared parent. Bing. Problem solved.
 
-**This may seem straightforward, but we've also created a strong reference cycle between ClassA and ClassB.**
+**This may seem straightforward, but we've also created a strong reference cycle between ClassP and ClassC.**
+
+**Notes 📝**: there is now a `WeakInjected` that can be used to inject `ClassP`in `ClassC`without creating cycles.
 
 As a general rule, you don't want to do this, but you should note that it's in fact possible to break the cycle by releasing the lazily instantiated object manually at some point in your code.
 
@@ -111,3 +113,29 @@ extension ClassC {
     }
 }
 ```
+
+## Weak Injection and Lazy Weak Injection
+
+To solve the previous problem, you can also use weak injection.
+
+```swift
+class ClassP {
+    @Injected var c: ClassC
+}
+
+class ClassC {
+    @LazyWeakInjected var p: ClassP?
+}
+```
+
+With registration like...
+
+```swift
+register { ClassP() }
+register { ClassC() }
+```
+
+The parent class has a reference to its child, and the child obtains a weak reference back to its shared parent (the reference itself is a strong reference to a internal box object `WeakObject` that itself holds a weak reference to the value `ClassC`).
+Weak injection is solving memory retain cycle while lazy injection is solving dependency cycle.
+
+Bing. Problem solved.

--- a/Documentation/Injection.md
+++ b/Documentation/Injection.md
@@ -1,4 +1,4 @@
-#  Resolver: Injection Strategies
+# Resolver: Injection Strategies
 
 ## Terminology
 
@@ -11,7 +11,7 @@ There are five primary ways of performing dependency injection using Resolver:
 5. [Service Locator](#locator)
 6. [Annotation](#annotation) (NEW)
 
-The names and numbers come from the *Inversion of Control* design pattern. For a more thorough discussion, see the classic arcticle by [Martin Fowler](https://martinfowler.com/articles/injection.html).
+The names and numbers come from the _Inversion of Control_ design pattern. For a more thorough discussion, see the classic article by [Martin Fowler](https://martinfowler.com/articles/injection.html).
 
 Here I'll simply provide a brief description and an example of implementing each using Resolver.
 
@@ -23,7 +23,7 @@ The first injection technique is to define a interface for the injection, and in
 
 #### The Class
 
-```
+```swift
 class XYZViewModel {
 
     lazy var fetcher: XYZFetching = getFetcher()
@@ -38,7 +38,7 @@ class XYZViewModel {
 
 #### The Dependency Injection Code
 
-```
+```swift
 extension XYZViewModel: Resolving {
     func getFetcher() -> XYZFetching { return resolver.resolve() }
     func getService() -> XYZService { return resolver.resolve() }
@@ -54,13 +54,13 @@ Note that you still want to call `resolve()` within `getFetcher()` and `getServi
 
 #### Pros
 
-* Lightweight.
-* Hides dependency injection system from class.
-* Useful for classes like UIViewController where you don't have access during the initialization process.
+- Lightweight.
+- Hides dependency injection system from class.
+- Useful for classes like UIViewController where you don't have access during the initialization process.
 
 #### Cons
 
-* Writing an accessor function for every service that needs to be injected.
+- Writing an accessor function for every service that needs to be injected.
 
 ## <a name=property></a>2. Property Injection
 
@@ -85,7 +85,7 @@ class XYZViewModel {
 
 #### The Dependency Injection Code
 
-```
+```swift
 func setupMyRegistrations {
     register { XYZViewModel() }
         .resolveProperties { (resolver, model) in
@@ -103,14 +103,14 @@ func setupMyRegistrations {
 
 #### Pros
 
-* Clean.
-* Also fairly lightweight.
+- Clean.
+- Also fairly lightweight.
 
 #### Cons
 
-* Exposes internals as public variables.
-* Harder to ensure that an object has been given everything it needs to do its job.
-* More work on the registration side of the fence.
+- Exposes internals as public variables.
+- Harder to ensure that an object has been given everything it needs to do its job.
+- More work on the registration side of the fence.
 
 ## <a name=constructor></a>3. Constructor Injection
 
@@ -120,7 +120,7 @@ A Constructor is the Java term for a Swift Initializer, but the idea is the same
 
 #### The Class
 
-```
+```swift
 class XYZViewModel {
 
     private var fetcher: XYZFetching
@@ -141,7 +141,7 @@ class XYZViewModel {
 
 #### The Dependency Injection Code
 
-```
+```swift
 func setupMyRegistrations {
     register { XYZViewModel(fetcher: resolve(), service: resolve()) }
     register { XYZFetcher() as XYZFetching }
@@ -151,26 +151,26 @@ func setupMyRegistrations {
 
 #### Pros
 
-* Ensures that the object has everything it needs to do its job, as the object can't be constructed otherwise.
-* Hides dependencies as private or internal.
-* Less code needed for the registration factory.
+- Ensures that the object has everything it needs to do its job, as the object can't be constructed otherwise.
+- Hides dependencies as private or internal.
+- Less code needed for the registration factory.
 
 #### Cons
 
-* Requires object to have initializer with all parameters needed.
-* More boilerplace code needed in the object initializer to transfer parameters to object properties.
+- Requires object to have initializer with all parameters needed.
+- More boilerplate code needed in the object initializer to transfer parameters to object properties.
 
 ## <a name=method></a>4. Method Injection
 
 #### Definition
 
-This is listed for competeness, even though it's not a pattern that uses Resolver directly.
+This is listed for completeness, even though it's not a pattern that uses Resolver directly.
 
 Method Injection is pretty much what it says, injecting the object needed into a given method.
 
 #### The Class
 
-```
+```swift
 class XYZViewModel {
 
     func load(fetcher: XYZFetching, service: XYZFetching) -> Data {
@@ -186,12 +186,12 @@ You've already seen it. In the load function, the service object is passed into 
 
 #### Pros
 
-* Allows callers to configure the behavior of a method on the fly.
-* Allows callers to construct their own behaviors and pass them into the method.
+- Allows callers to configure the behavior of a method on the fly.
+- Allows callers to construct their own behaviors and pass them into the method.
 
 #### Cons
 
-* Exposes those behaviors to all of the classes that use it.
+- Exposes those behaviors to all of the classes that use it.
 
 #### Note
 
@@ -207,7 +207,7 @@ Technically, Service Locator is its own Design Pattern, distinct from Dependency
 
 #### The Class
 
-```
+```swift
 class XYZViewModel {
 
     var fetcher: XYZFetching = Resolver.resolve()
@@ -222,7 +222,7 @@ class XYZViewModel {
 
 #### The Dependency Injection Code
 
-```
+```swift
 func setupMyRegistrations {
     register { XYZFetcher() as XYZFetching }
     register { XYZService() }
@@ -231,12 +231,12 @@ func setupMyRegistrations {
 
 #### Pros
 
-* Less code.
-* Useful for classes like UIViewController where you don't have access during the initialization process.
+- Less code.
+- Useful for classes like UIViewController where you don't have access during the initialization process.
 
 #### Cons
 
-* Exposes the dependency injection system to all of the classes that use it.
+- Exposes the dependency injection system to all of the classes that use it.
 
 ## <a name=annotation></a>6. Annotation
 
@@ -246,7 +246,7 @@ Annotation uses comments or other metadata to indication that dependency injecti
 
 #### The Class
 
-```
+```swift
 class XYZViewModel {
 
     @Injected var fetcher: XYZFetching
@@ -261,7 +261,7 @@ class XYZViewModel {
 
 #### The Dependency Injection Code
 
-```
+```swift
 func setupMyRegistrations {
     register { XYZFetcher() as XYZFetching }
     register { XYZService() }
@@ -270,14 +270,14 @@ func setupMyRegistrations {
 
 #### Pros
 
-* Less code.
-* Hides the specifics of the injection system. One could easily make an Injected property wrapper to support any DI system.
-* Useful for classes like UIViewController where you don't have access during the initialization process.
+- Less code.
+- Hides the specifics of the injection system. One could easily make an Injected property wrapper to support any DI system.
+- Useful for classes like UIViewController where you don't have access during the initialization process.
 
 #### Cons
 
-* Exposes the fact that a dependency injection system is used.
+- Exposes the fact that a dependency injection system is used.
 
-## Additonal Resources
+## Additional Resources
 
 This just skims the surface. For a more in-depth look at the pros and cons, see: [Inversion of Control Containers and the Dependency Injection pattern ~ Martin Fowler](https://martinfowler.com/articles/injection.html).

--- a/Documentation/Installation.md
+++ b/Documentation/Installation.md
@@ -1,10 +1,10 @@
-#  Resolver: Installation
+# Resolver: Installation
 
 ## Swift Package Manager
 
 Resolver is available through Swift Package Manager. To install it simply include it in your package dependencies:
 
-```
+```swift
 dependencies: [
     .package(url: "https://github.com/hmlongco/Resolver.git", from: "1.1.2"),
 ]
@@ -16,15 +16,15 @@ Or in Xcode via File > Swift Packages > Add Package Dependency...
 
 Resolver is available through CocoaPods. To install it, simply add the following line to your Podfile:
 
-```
+```ruby
 pod "Resolver"
 ```
 
-Special thanks to [Khoa Pham](https://github.com/onmyway133) for making the *Resolver* repo available on CocoaPods.
+Special thanks to [Khoa Pham](https://github.com/onmyway133) for making the _Resolver_ repo available on CocoaPods.
 
 ## Carthage
 
-The original plan was for Resolver to be Carthage compliant but now with the introduction of Swift Package Manager for iOS I'm going to skip official Carthage support. 
+The original plan was for Resolver to be Carthage compliant but now with the introduction of Swift Package Manager for iOS I'm going to skip official Carthage support.
 
 But all is not lost! If you're using Carthage and want to use Resolver just add it directly in your project as shown below.
 
@@ -42,9 +42,9 @@ Or you can follow the instructions below.
 
 ## Supporting iOS 9 and iOS 10
 
-The current version of Resolver targets iOS 11 as the minimum supported SDK. 
+The current version of Resolver targets iOS 11 as the minimum supported SDK.
 
-If you need iOS 10 or earlier then your best option is to add Resolver directly to your project and remove the property wrapper section from the Resolver source code.  
+If you need iOS 10 or earlier then your best option is to add Resolver directly to your project and remove the property wrapper section from the Resolver source code.
 
 That's basically everything from the `// Swift Property Wrappers` comment to the end of the file.
 

--- a/Documentation/Introduction.md
+++ b/Documentation/Introduction.md
@@ -1,4 +1,4 @@
-#  Resolver: Introduction
+# Resolver: Introduction
 
 ## Definitions
 
@@ -8,13 +8,13 @@ Computer Science definitions aside, Dependency Injection pretty much boils down 
 
 | **Giving an object the things it needs to do its job.**
 
-Dependency Injection allows us to write code that's loosely coupled, and as such, easier to reuse, to mock, and  to test.
+Dependency Injection allows us to write code that's loosely coupled, and as such, easier to reuse, to mock, and to test.
 
 ## Quick Example
 
-Here's an object that needs  to talk to an NetworkService.
+Here's an object that needs to talk to an NetworkService.
 
-```
+```swift
 class MyViewModel {
     let service = NetworkService()
     func load() {
@@ -23,9 +23,9 @@ class MyViewModel {
 }
 ```
 
-This class is considered to be *tightly coupled* to its dependency, NetworkService.
+This class is considered to be _tightly coupled_ to its dependency, NetworkService.
 
-The problem is that MyObject will *always* create it's own service, of type NetworkService, and that's it.
+The problem is that MyObject will _always_ create it's own service, of type NetworkService, and that's it.
 
 But what if at some point we want MyViewModel to pull its data from a disk instead? What if we want to reuse MyViewModel somewhere else in the code, or in another app, and have it pull different data?
 
@@ -35,9 +35,9 @@ Or simply have the app run completely on mocked data for QA purposes?
 
 ## Injection
 
-Now, consider an object that depends upon an instance of NetworkService being passed to it, using what us DI types term *Property Injection*.
+Now, consider an object that depends upon an instance of NetworkService being passed to it, using what us DI types term _Property Injection_.
 
-```
+```swift
 class MyViewModel {
     var service: NetworkServicing!
     func load() {
@@ -48,7 +48,7 @@ class MyViewModel {
 
 MyViewModel now depends on the network service being set beforehand, as opposed to directly instantiating a copy of NetworkService itself.
 
-Further, MyViewModel is now using a protocol named NetworkServicing, which in turn defines a  `getData()` method.
+Further, MyViewModel is now using a protocol named NetworkServicing, which in turn defines a `getData()` method.
 
 Those two changes allow us to meet all of the goals mentioned above.
 
@@ -62,11 +62,11 @@ Well, you could, but the better answer is to use Dependency Injection.
 
 ## Registration
 
-Dependency Injection works in two phases: *Registration* and *Resolution*.
+Dependency Injection works in two phases: _Registration_ and _Resolution_.
 
-Registration consists of registering the classes and objects we're going to need,  as well as providing a *factory* closure to create an instance of one when needed.
+Registration consists of registering the classes and objects we're going to need, as well as providing a _factory_ closure to create an instance of one when needed.
 
-```
+```swift
 Resolver.register { NetworkService() as NetworkServicing }
 
 Resolver.register { MyViewModel() }.resolveProperties { (_, model) in
@@ -78,7 +78,7 @@ The above looks a bit complex, but it's actually fairly straightforward.
 
 First, we registered a factory (closure) that will create an instance of NetworkService when needed. The type being registered is [automatically inferred](Types.md) using the result type returned by the factory.
 
-Hence we're creating a NetworkService, but we're acutally registering the protocol NetworkServicing.
+Hence we're creating a NetworkService, but we're actually registering the protocol NetworkServicing.
 
 Similarly, we registered a factory to create MyViewModel's when needed, and we also added a resolveProperties closure to [resolve](Resolving.md) its service property.
 
@@ -86,7 +86,7 @@ Similarly, we registered a factory to create MyViewModel's when needed, and we a
 
 Once registered, any object can ask Resolver to provide (resolve) an object of that type.
 
-```
+```swift
 var viewModel: MyViewModel = Resolver.resolve()
 ```
 
@@ -94,27 +94,29 @@ var viewModel: MyViewModel = Resolver.resolve()
 
 So we registered a factory, and asked Resolver to resolve it, and it worked... but why go to the extra trouble?
 
-Why we don't just directly instantiate  MyViewModel and be done with it?
-```
+Why we don't just directly instantiate MyViewModel and be done with it?
+
+```swift
 var viewModel = MyViewModel()
 viewModel.service = NetworkService()
 ```
+
 Well, there are several reasons why this is a bad idea, but let's start with two:
 
 First, what happens if NetworkService in turn required other classes or objects to do its job? And what happens if those objects need references to other objects, services, and system resources?
 
-```
+```swift
 var viewModel = MyViewModel()
 viewModel.service = NetworkService(TokenVendor.token(AppDelegate.seed))
 ```
 
 You're literally left with needing to construct the objects needed... to build the objects needed... to build the single instance of the object that you actually wanted in the first place.
 
-Those additonal objects are known as *dependencies*.
+Those additional objects are known as _dependencies_.
 
 Second, and worse, the constructing class now knows the internals and requirements for MyViewModel, and for NetworkService, and it also knows about TokenVendor and its requirements.
 
-It's now tightly *coupled* to the behavior and distinct implementations of all of those classes... when all it really wanted to do was talk to a MyViewModel.
+It's now tightly _coupled_ to the behavior and distinct implementations of all of those classes... when all it really wanted to do was talk to a MyViewModel.
 
 ## ViewControllers, ViewModel, and Services. Oh, my.
 
@@ -122,7 +124,7 @@ To demonstrate, let's use a more complex example.
 
 Here we have a UIViewController named MyViewController that requires an instance of an XYZViewModel.
 
-```
+```swift
 class MyViewController: UIViewController {
     var viewModel: XYZViewModel!
 }
@@ -132,7 +134,7 @@ The XYZViewModel needs an instance of an object that implements a XYZFetching pr
 
 The XYZService, in turn, needs a reference to an XYZSessionService to do its job.
 
-```
+```swift
 class XYZViewModel {
     private var fetcher: XYZFetching
     private var updater: XYZUpdating
@@ -143,7 +145,7 @@ class XYZViewModel {
         self.updater = updater
         self.service = service
     }
-    // Implmentation
+    // Implementation
 }
 
 class XYZCombinedService: XYZFetching, XYZUpdating {
@@ -151,15 +153,15 @@ class XYZCombinedService: XYZFetching, XYZUpdating {
     init(_ session: XYZSessionService) {
         self.session = session
     }
-    // Implmentation
+    // Implementation
 }
 
 struct XYZService {
-    // Implmentation
+    // Implementation
 }
 
 class XYZSessionService {
-    // Implmentation
+    // Implementation
 }
 ```
 
@@ -169,11 +171,11 @@ Note that the initializers for XYZViewModel and XYZCombinedService are each pass
 
 Let's use Resolver to register these classes.
 
-Here we're extending the base Resolver class with the ResolverRegistering protcol, which pretty much just tells Resolver that we've added the registerAllServices() function.
+Here we're extending the base Resolver class with the ResolverRegistering protocol, which pretty much just tells Resolver that we've added the registerAllServices() function.
 
 The `registerAllServices` function is automatically called by Resolver the first time it's asked to resolve a service, in effect performing a one-time initialization of the resolution system.
 
-```
+```swift
 extension Resolver: ResolverRegistering {
     public static func registerAllServices() {
         register { XYZViewModel(fetcher: resolve(), updater: resolve(), service: resolve()) }
@@ -196,7 +198,7 @@ Now we've registered all of the objects our app is going to use. But what starts
 
 Well, MyViewController is the one who wanted a XYZViewModel, so let's rewrite it as follows...
 
-```
+```swift
 class MyViewController: UIViewController, Resolving {
     lazy var viewModel: XYZViewModel = resolver.resolve()
 }
@@ -204,9 +206,9 @@ class MyViewController: UIViewController, Resolving {
 
 Adopting the Resolving protocol injects the default resolver instance into MyViewController (Interface Injection). Calling resolve on that instance allows it to request a XYZViewModel from Resolver.
 
-Resolver processes the request, finds the right factory to make a XYZViewModel, and tells it to do so. 
+Resolver processes the request, finds the right factory to make a XYZViewModel, and tells it to do so.
 
-The XYZViewModel factory, in turn, triggers the resolution of the types that *it* needs (XYZFetching, XYZUpdating, and XYZService), and so on, down the chain. Eventually, the XYZViewModel factory gets everything it needs, returns the correct instance, and MyViewController gets its view model.
+The XYZViewModel factory, in turn, triggers the resolution of the types that _it_ needs (XYZFetching, XYZUpdating, and XYZService), and so on, down the chain. Eventually, the XYZViewModel factory gets everything it needs, returns the correct instance, and MyViewController gets its view model.
 
 MyViewController doesn't know the internals of XYZViewModel, nor does it know about XYZFetcher's, XYZUpdater's, XYZService's, or XYZSessionService's.
 
@@ -220,7 +222,7 @@ Okay, you might think. That's pretty cool, but earlier you mentioned other benef
 
 Consider the following change to the above code:
 
-```
+```swift
 extension Resolver {
     static func registerAllServices() {
         register { XYZViewModel(fetcher: resolve(), updater: resolve(), service: resolve()) }
@@ -247,16 +249,17 @@ And both MyViewController and XYZViewModel are none the wiser.
 
 Same for unit testing. Add something like the following to the unit test code.
 
-```
+```swift
 let data = ["name":"Mike", "developer":true]
 register { XYZTestSessionService(data) as XYZSessionService }
 let viewModel: XYZViewModel = Resolver.resolve()
 ```
 
-Now your unit and integration tests for XYZViewModel as using XYZTestSessionService, which povides stable, known data to the model.
+Now your unit and integration tests for XYZViewModel as using XYZTestSessionService, which provides stable, known data to the model.
 
 Do it again.
-```
+
+```swift
 let data = ["name":"Boss", "developer":false]
 register { XYZTestSessionService(data) as XYZSessionService }
 let viewModel: XYZViewModel = Resolver.resolve()

--- a/Documentation/Names.md
+++ b/Documentation/Names.md
@@ -1,4 +1,4 @@
-#  Resolver: Named Instances
+# Resolver: Named Instances
 
 ## Why name a registration?
 
@@ -18,7 +18,6 @@ The first line registers a String named `appKey`.
 The factory in the second line resolves a String parameter named `appKey`, and passes it to the `XYZSessionService` initialization function.
 
 This is a good way to get authentication keys, application keys, and other values to the objects that need them.
-
 
 ## Example: Mocking Data
 
@@ -60,7 +59,6 @@ register(name: "edit") { XYZViewModelEditing() as XYZViewModelProtocol }
 Here we're registering two instances of the same protocol, `XYZViewModelProtocol`.
 
 But one view model appears to be specific to adding things, while the other's behavior leans more towards editing.
-
 
 ```swift
 class ViewController: UIViewController, Resolving {

--- a/Documentation/Optionals.md
+++ b/Documentation/Optionals.md
@@ -1,4 +1,4 @@
-#  Resolver: Optionals
+# Resolver: Optionals
 
 ## Why the expected result is not the expected result
 
@@ -55,10 +55,11 @@ This could be helpful if for some reason you wanted to resolve to a specific ins
 var abc: ABCServicing? = Resolver.resolve(ABCService.self)
 ```
 
-##  Optional annotation
+## Optional annotation
 
 An annotation is available that supports optional resolving. If the service is not registered, then the value will be nil, otherwise it will be not nil:
-```
+
+```swift
 class InjectedViewController: UIViewController {
     @OptionalInjected var service: XYZService?
     func load() {

--- a/Documentation/Protocols.md
+++ b/Documentation/Protocols.md
@@ -1,4 +1,4 @@
-#  Resolver: Protocols
+# Resolver: Protocols
 
 ### Registering a protocol
 
@@ -12,7 +12,7 @@ main.register { XYZCombinedService() as XYZFetching }
 
 Here, we're registering how to get an object that implements the XYZFetching protocol.
 
-The registration factory is *creating* an object of type `XYZCombinedService`, but it's *returning* a type of `XYZFetching`, and that's what's being registered.
+The registration factory is _creating_ an object of type `XYZCombinedService`, but it's _returning_ a type of `XYZFetching`, and that's what's being registered.
 
 ### Registering an object with multiple protocols
 
@@ -45,13 +45,13 @@ In the second line you're asking Resolver to again resolve a XYZCombinedService 
 
 The last line registers how to make an XYZCombinedService().
 
-Now, both the XYZFetching and XYZUpdating protocols are tied to the same object, and given the default [graph scope](Scopes.md), only one instance of XYZCombinedService will be constructed during a specific [resolution cycle](Cycle.md) when both protocols are resovled.
+Now, both the XYZFetching and XYZUpdating protocols are tied to the same object, and given the default [graph scope](Scopes.md), only one instance of XYZCombinedService will be constructed during a specific [resolution cycle](Cycle.md) when both protocols are resolved.
 
 ### Protocols sharing the same instance across resolution cycles
 
 The preceding example shares `XYZCombinedService` during a given [resolution cycle](Cycle.md).
 
-But what if we want any instance of `XYZFetching` or `XYZUpdating` to *always* share the same instance?
+But what if we want any instance of `XYZFetching` or `XYZUpdating` to _always_ share the same instance?
 
 ```swift
 main.register { XYZCombinedService() }

--- a/Documentation/Registration.md
+++ b/Documentation/Registration.md
@@ -1,10 +1,10 @@
-#  Resolver: Registration
+# Resolver: Registration
 
 ## Add the AppDelegate
 
 Add a file named `AppDelegate+Injection.swift` to your project and add the following code:
 
-```
+```swift
 import Resolver
 
 extension Resolver: ResolverRegistering {
@@ -16,13 +16,13 @@ extension Resolver: ResolverRegistering {
 
 If you're using frameworks, CocoaPods or Carthage, you'll need the `import Resolver` line. If you added Resolver.swift directly to your project, just delete that line.
 
-That's it. You've added the basic level of intergration.
+That's it. You've added the basic level of integration.
 
 But as is, it's not very useful until you actually register some classes.
 
 ## Add Injection Files<a name=files></a>
 
-It's a common practice with Resolver, Swinject, and other DI systems to add addtional "injection" files to your project to support the dependencies needed by a particular part of the code base.
+It's a common practice with Resolver, Swinject, and other DI systems to add additional "injection" files to your project to support the dependencies needed by a particular part of the code base.
 
 Let's say you have a group in your project folder named "NetworkServices", and you want to register some of those services for use by Resolver.
 
@@ -30,7 +30,7 @@ Let's say you have a group in your project folder named "NetworkServices", and y
 
 Go to the NetworkServices folder and add a swift file named: `NetworkServices+Injection.swift`, then add the following to that file...
 
-```
+```swift
 extension Resolver {
     public static func registerMyNetworkServices() {
 
@@ -40,9 +40,9 @@ extension Resolver {
 
 #### 2. Update the master file.
 
-Now, go back to your  `AppDelegate+Injection.swift` file and add a reference to `registerMyNetworkServices`.
+Now, go back to your `AppDelegate+Injection.swift` file and add a reference to `registerMyNetworkServices`.
 
-```
+```swift
 extension Resolver: ResolverRegistering {
     public static func registerAllServices() {
         registerMyNetworkServices()
@@ -54,11 +54,11 @@ Resolver will automatically call `registerAllServices`, and that function in tur
 
 #### 3. Add your own registrations.
 
-Now, housekeeping completed, return to  `NetworkServices+Injection.swift` and add your own registrations.
+Now, housekeeping completed, return to `NetworkServices+Injection.swift` and add your own registrations.
 
 Just as an example:
 
-```
+```swift
 import Resolver
 
 extension Resolver {
@@ -76,15 +76,14 @@ extension Resolver {
         // Register XYZSessionService and return instance in factory closure
         register { XYZSessionService() }
     }
-    
+
 }
 ```
 
-That's it. Resolver uses  Swift [type inference](Types.md) to automatically determine and register the type of object being returned by the registration factory.
+That's it. Resolver uses Swift [type inference](Types.md) to automatically determine and register the type of object being returned by the registration factory.
 
 And in the case of `XYZNetworkService`, Resolver is used to infer the type of the session parameter that's needed to initialize a `XYZNetworkService`.
 
 This works with classes, structs, and protocols, though there are a few special cases and considerations for [protocols](Protocols.md).
 
 You can also register [value types](Names.md), though that too has a few special considerations.
-

--- a/Documentation/Resolving.md
+++ b/Documentation/Resolving.md
@@ -1,4 +1,4 @@
-#  Resolver: Resolving
+# Resolver: Resolving
 
 ## Resolve using Resolver
 
@@ -10,7 +10,7 @@ class MyViewController: UIViewController {
 }
 ```
 
-Used in this fashion, Resolver is acting as a *Service Locator*.
+Used in this fashion, Resolver is acting as a _Service Locator_.
 
 There are pros and cons to the Service Locator approach, the primary two being writing less code vs having your view controllers and other objects "know" about about your Service Locator (i.e. Resolver.)
 
@@ -34,7 +34,6 @@ Implementing the Resolving protocol injects the default Resolver into that class
 
 All resolution methods available in Resolver (e.g. `resolve()`, `optional()`) are available from the injected variable.
 
-
 ## Resolve using Interface Injection
 
 If you're a bit more of a Dependency Injection purist, you can wrap Resolver as follows.
@@ -47,7 +46,7 @@ extension MyViewController: Resolving {
 }
 ```
 
-And now the code contained in  `MyViewController` becomes:
+And now the code contained in `MyViewController` becomes:
 
 ```swift
 class MyViewController: UIViewController {
@@ -57,7 +56,7 @@ class MyViewController: UIViewController {
 
 All the view controller knows is that a function was provided that gives it the view model that it wants.
 
-Note that we're using an injected function to set our variable. It's *possbile* to do:
+Note that we're using an injected function to set our variable. It's _possible_ to do:
 
 ```swift
 extension MyViewController: Resolving {
@@ -79,7 +78,7 @@ class MyViewController: UIViewController, Resolving {
 }
 ```
 
-This will generate a Swift compiler error: *Cannot use instance member 'resolver' within property initializer; property initializers run before 'self' is available.*
+This will generate a Swift compiler error: _Cannot use instance member 'resolver' within property initializer; property initializers run before 'self' is available._
 
 Or to put it another way, Swift can't use variables or call functions before all variables are known to be initialized. Adding `lazy` fixes the problem, and also gives us the flexibility to do things like the following:
 
@@ -111,9 +110,8 @@ Note the second line of code. You should also remember that Explicitly Unwrapped
 
 [Read more about Optionals.](Optionals.md)
 
-
 ## ResolverStoryboard
 
-You can also have Resolver *automatically* resolve view controllers instantiated from Storyboards. (Well, automatically from the view controller's standpoint, anyway.)
+You can also have Resolver _automatically_ resolve view controllers instantiated from Storyboards. (Well, automatically from the view controller's standpoint, anyway.)
 
 [See: Storyboard support.](Storyboards.md)

--- a/Documentation/Scopes.md
+++ b/Documentation/Scopes.md
@@ -1,4 +1,4 @@
-#  Resolver: Scopes
+# Resolver: Scopes
 
 ## What's a scope, and why do I want one?
 
@@ -6,11 +6,11 @@ Scopes are used to control the lifecycle of a given object instance.
 
 Resolver has five built-in scopes:
 
-* [Application](#application)
-* [Cached](#cached)
-* [Graph](#graph) (default)
-* [Shared](#shared)
-* [Unique](#unique)
+- [Application](#application)
+- [Cached](#cached)
+- [Graph](#graph) (default)
+- [Shared](#shared)
+- [Unique](#unique)
 
 All scopes, with the exception of `unique`, are basically caches, and those caches are used to keep track of the objects they create.
 
@@ -65,9 +65,9 @@ var viewModel: XYZViewModel = resolver.resolve()
 
 When the call to `resolve` is made, Resolver needs to create an instance of `XYZViewModel`, so it locates and calls the proper factory. That factory is happy to comply, but in order to make a XYZViewModel it's first going to need to resolve all of that object's initialization parameters.
 
-This starts with `fetcher`, which ultimately resolves to `XYZCombinedService`, so the `XYZCombinedService` factory is called to create one. This instance is returned and it's *also* cached in the current object graph.
+This starts with `fetcher`, which ultimately resolves to `XYZCombinedService`, so the `XYZCombinedService` factory is called to create one. This instance is returned and it's _also_ cached in the current object graph.
 
-The next parameter is an `updater`, which coincidentally for this example *also* resolves to `XYZCombinedService`.
+The next parameter is an `updater`, which coincidentally for this example _also_ resolves to `XYZCombinedService`.
 
 But since we've already resolved `XYZCombinedService` once during this cycle, the cached instance will be returned as the parameter for `updater`.
 
@@ -79,7 +79,7 @@ If you don't want this behavior, and if every request should get its own `unique
 
 ## Scope: Shared<a name=shared></a>
 
-This scope stores a *weak* reference to the resolved instance.
+This scope stores a _weak_ reference to the resolved instance.
 
 ```
 main.register { MyViewModel() }

--- a/Documentation/Storyboards.md
+++ b/Documentation/Storyboards.md
@@ -1,12 +1,13 @@
-#  Resolver: Storyboards
+# Resolver: Storyboards
 
 NOTE: As of Swift 5.1, we can now perform annotation using Property Wrappers. (See [Annotation](https://github.com/hmlongco/Resolver/blob/master/Documentation/Annotation.md).)
 
-```
+```swift
 class MyViewController: UIViewController {
     @Injected var viewModel: XYZViewModel
 }
 ```
+
 I highly recommend this approach over the other methods shown below.
 
 ## Property Injection
@@ -15,16 +16,17 @@ Resolver supports automatic UIViewController property injection using the Storyb
 
 Let's assume the following view controller, which needs a XYZViewModel in order to function.
 
-```
+```swift
 class MyViewController: UIViewController {
     var viewModel: XYZViewModel!
 }
 ```
+
 ### Step 1: Add the resolution factory method.
 
 Add the following to your section's [xxxxx+Injection.swift file](Registration.md#files):
 
-```
+```swift
 extension MyViewController: StoryboardResolving {
     func resolveViewController(_ resolver: Resolver) {
         self.viewModel = resolver.optional()
@@ -32,7 +34,7 @@ extension MyViewController: StoryboardResolving {
 }
 ```
 
-Note that we're using `.optional()` here, since XYZViewModel is an *ImplicitlyUnwrappedOptional*.
+Note that we're using `.optional()` here, since XYZViewModel is an _ImplicitlyUnwrappedOptional_.
 
 ### Step 2: Tell the Storyboard that your view controller needs to be resolved.
 
@@ -50,15 +52,15 @@ From its perspective, all of its properties just magically appear, ready and wai
 
 Add the following to your section's [xxxxx+Injection.swift file](Registration.md#files):
 
-```
+```swift
 extension MyViewController: Resolving {
     func makeViewModel() -> XYZViewModel { return resolver.resolve() }
 }
 ```
 
-And now the code contained in  `MyViewController` becomes:
+And now the code contained in `MyViewController` becomes:
 
-```
+```swift
 class MyViewController: UIViewController {
     lazy var viewModel = makeViewModel()
 }
@@ -74,7 +76,7 @@ Some Dependency Injection systems like [SwinjectStoryboard](https://github.com/S
 
 Here's the equivalent Step 1 code in SwinjectStoryboard.
 
-```
+```swift
 extension SwinjectStoryboard {
     class func setupMyStoryboard() {
         defaultContainer.storyboardInitCompleted(MyViewController.self) { (r, vc: MyViewController) in

--- a/Documentation/Swinject.md
+++ b/Documentation/Swinject.md
@@ -1,3 +1,3 @@
-#  Resolver vs. Swinject
+# Resolver vs. Swinject
 
 Not yet written.

--- a/Documentation/Types.md
+++ b/Documentation/Types.md
@@ -38,7 +38,7 @@ Here the variable type is ABCService, so Resolver will lookup the registration f
 
 You can also explicitly tell Resolver the type of object or protocol you want to register or resolve.
 
-```
+```swift
 Resolver.register(ABCServicing.self) { ABCService() }
 var abc = Resolver.resolve(ABCServicing.self)
 ```

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Dependency Injection frameworks support the [Inversion of Control](https://en.wi
 
 | **Giving an object the things it needs to do its job.**
 
-That's it. Dependency injection allows us to write code that's loosely coupled, and as such, easier to reuse, to mock, and  to test.
+That's it. Dependency injection allows us to write code that's loosely coupled, and as such, easier to reuse, to mock, and to test.
 
 For more, see: [A Gentle Introduction to Dependency Injection.](https://github.com/hmlongco/Resolver/blob/master/Documentation/Introduction.md)
 
@@ -35,21 +35,22 @@ class BasicInjectedViewController: UIViewController {
     @LazyInjected var service2: XYZLazyService
 }
 ```
+
 Just add the Injected keyword and your dependencies will be resolved automatically. See the [Annotation](https://github.com/hmlongco/Resolver/blob/master/Documentation/Annotation.md) documentation for more on this and other strategies.
 
 ## Features
 
 Resolver is implemented in just over 300 lines of actual code, but it packs a ton of features into those 300 lines.
 
-* [Automatic Type Inference](https://github.com/hmlongco/Resolver/blob/master/Documentation/Types.md)
-* [Scopes: Application, Cached, Graph, Shared, and Unique](https://github.com/hmlongco/Resolver/blob/master/Documentation/Scopes.md)
-* [Protocols](https://github.com/hmlongco/Resolver/blob/master/Documentation/Protocols.md)
-* [Optionals](https://github.com/hmlongco/Resolver/blob/master/Documentation/Optionals.md)
-* [Named Instances](https://github.com/hmlongco/Resolver/blob/master/Documentation/Names.md)
-* [Argument Passing](https://github.com/hmlongco/Resolver/blob/master/Documentation/Arguments.md)
-* [Custom Containers & Nested Containers](https://github.com/hmlongco/Resolver/blob/master/Documentation/Containers.md)
-* [Cyclic Dependency Support](https://github.com/hmlongco/Resolver/blob/master/Documentation/CyclicDependencies.md)
-* [Storyboard Support](https://github.com/hmlongco/Resolver/blob/master/Documentation/Storyboards.md)
+- [Automatic Type Inference](https://github.com/hmlongco/Resolver/blob/master/Documentation/Types.md)
+- [Scopes: Application, Cached, Graph, Shared, and Unique](https://github.com/hmlongco/Resolver/blob/master/Documentation/Scopes.md)
+- [Protocols](https://github.com/hmlongco/Resolver/blob/master/Documentation/Protocols.md)
+- [Optionals](https://github.com/hmlongco/Resolver/blob/master/Documentation/Optionals.md)
+- [Named Instances](https://github.com/hmlongco/Resolver/blob/master/Documentation/Names.md)
+- [Argument Passing](https://github.com/hmlongco/Resolver/blob/master/Documentation/Arguments.md)
+- [Custom Containers & Nested Containers](https://github.com/hmlongco/Resolver/blob/master/Documentation/Containers.md)
+- [Cyclic Dependency Support](https://github.com/hmlongco/Resolver/blob/master/Documentation/CyclicDependencies.md)
+- [Storyboard Support](https://github.com/hmlongco/Resolver/blob/master/Documentation/Storyboards.md)
 
 TLDR: If nothing else, make sure you read about [Automatic Type Inference](https://github.com/hmlongco/Resolver/blob/master/Documentation/Types.md), [Scopes](https://github.com/hmlongco/Resolver/blob/master/Documentation/Scopes.md), and [Optionals](https://github.com/hmlongco/Resolver/blob/master/Documentation/Optionals.md).
 
@@ -64,9 +65,11 @@ Using Resolver is a simple, three-step process:
 ## Installation
 
 Resolver supports CocoaPods and the Swift Package Manager.
+
 ```swift
 pod "Resolver"
 ```
+
 Resolver itself is just a single source file (Resolver.swift), so it's also easy to simply download the file and add it to your project.
 
 Note that the current version of Resolver (1.1) supports Swift 5.1 and that the minimum version of iOS currently supported with this release is iOS 11.
@@ -83,30 +86,30 @@ And unlike some other systems, Resolver is written in 100% Swift 5, with no Obje
 
 Further, Resolver:
 
-* Is tested in production code.
-* Is thread safe (assuming your objects are thread safe).
-* Has a complete set of unit tests.
-* Is well-documented.
+- Is tested in production code.
+- Is thread safe (assuming your objects are thread safe).
+- Has a complete set of unit tests.
+- Is well-documented.
 
-Finally, with  [Automatic Type Inference](https://github.com/hmlongco/Resolver/blob/master/Documentation/Types.md) you also tend to write about 40-60% less dependency injection code using Resolver.
+Finally, with [Automatic Type Inference](https://github.com/hmlongco/Resolver/blob/master/Documentation/Types.md) you also tend to write about 40-60% less dependency injection code using Resolver.
 
 ## Author
 
 Resolver was designed, implemented, and documented by [Michael Long](https://www.linkedin.com/in/hmlong/), a Senior Lead iOS engineer at [CRi Solutions](https://www.clientresourcesinc.com/solutions/). CRi is a leader in developing cutting edge iOS, Android, and mobile web applications and solutions for our corporate and financial clients.
 
-* Email: [mlong@clientresourcesinc.com](mailto:mlong@clientresourcesinc.com)
-* Twitter: @hmlco
+- Email: [mlong@clientresourcesinc.com](mailto:mlong@clientresourcesinc.com)
+- Twitter: @hmlco
 
 ## License
 
 Resolver is available under the MIT license. See the LICENSE file for more info.
 
-## Additional Resouces
+## Additional Resources
 
-* [API Documentation](https://hmlongco.github.io/Resolver/Documentation/API/Classes/Resolver.html)
-* [Inversion of Control Design Pattern ~ Wikipedia](https://en.wikipedia.org/wiki/Inversion_of_control)
-* [Inversion of Control Containers and the Dependency Injection pattern ~ Martin Fowler](https://martinfowler.com/articles/injection.html)
-* [Nuts and Bolts of Dependency Injection in Swift](https://cocoacasts.com/nuts-and-bolts-of-dependency-injection-in-swift/)\
-* [Dependency Injection in Swift](https://cocoacasts.com/dependency-injection-in-swift)
-* [SwinjectStoryboard](https://github.com/Swinject/SwinjectStoryboard)
-* [Swift 5.1 Takes Dependency Injection to the Next Level](https://medium.com/better-programming/taking-swift-dependency-injection-to-the-next-level-b71114c6a9c6)
+- [API Documentation](https://hmlongco.github.io/Resolver/Documentation/API/Classes/Resolver.html)
+- [Inversion of Control Design Pattern Wikipedia](https://en.wikipedia.org/wiki/Inversion_of_control)
+- [Inversion of Control Containers and the Dependency Injection pattern ~ Martin Fowler](https://martinfowler.com/articles/injection.html)
+- [Nuts and Bolts of Dependency Injection in Swift](https://cocoacasts.com/nuts-and-bolts-of-dependency-injection-in-swift/)\
+- [Dependency Injection in Swift](https://cocoacasts.com/dependency-injection-in-swift)
+- [SwinjectStoryboard](https://github.com/Swinject/SwinjectStoryboard)
+- [Swift 5.1 Takes Dependency Injection to the Next Level](https://medium.com/better-programming/taking-swift-dependency-injection-to-the-next-level-b71114c6a9c6)

--- a/Resolver.podspec
+++ b/Resolver.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "Resolver"
-  s.version      = "1.1.4"
+  s.version      = "1.1.5"
   s.summary      = "An ultralight Dependency Injection / Service Locator framework for Swift on iOS."
   s.homepage     = "https://github.com/hmlongco/Resolver"
   s.license      = "MIT"

--- a/Resolver.xcodeproj/project.pbxproj
+++ b/Resolver.xcodeproj/project.pbxproj
@@ -346,7 +346,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
 				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				MARKETING_VERSION = 1.1.2;
+				MARKETING_VERSION = 1.1.5;
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_LDFLAGS = "$(inherited)";
 				OTHER_SWIFT_FLAGS = "$(inherited)";
@@ -379,7 +379,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
 				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				MARKETING_VERSION = 1.1.2;
+				MARKETING_VERSION = 1.1.5;
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_LDFLAGS = "$(inherited)";
 				OTHER_SWIFT_FLAGS = "$(inherited)";

--- a/Sources/Resolver/Resolver.swift
+++ b/Sources/Resolver/Resolver.swift
@@ -580,7 +580,7 @@ public extension UIViewController {
 #if swift(>=5.1)
 /// Immediate injection property wrapper.
 ///
-/// Wrapped dependent service is resolved immediately using Resolver.root upon struct initialization.
+/// Wrapped dependent service is resolved immediately using `Resolver.root` upon struct initialization.
 ///
 @propertyWrapper
 public struct Injected<Service> {
@@ -601,7 +601,7 @@ public struct Injected<Service> {
     }
 }
 
-/// Lazy injection property wrapper. Note that mbedded container and name properties will be used if set prior to service instantiation.
+/// Lazy injection property wrapper. Note that embedded container and name properties will be used if set prior to service instantiation.
 ///
 /// Wrapped dependent service is not resolved until service is accessed.
 ///
@@ -636,6 +636,10 @@ public struct LazyInjected<Service> {
     }
 }
 
+/// Optional injection property wrapper.
+///
+/// Wrapped dependent service is resolved immediately using Resolver.root upon struct initialization. If the service is not registered, then the value will be nil, otherwise it will be not nil.
+///
 @propertyWrapper
 public struct OptionalInjected<Service> {
     private var service: Service?

--- a/Sources/Resolver/Resolver.swift
+++ b/Sources/Resolver/Resolver.swift
@@ -708,6 +708,9 @@ public struct LazyWeakInjected<Service> where Service: AnyObject {
         self.name = name
         self.container = container
     }
+    public var isEmpty: Bool {
+        return weakObjectService == nil
+    }
     public var wrappedValue: Service? {
         mutating get {
             if self.weakObjectService == nil {

--- a/Tests/ResolverTests/ResolverInjectedTests.swift
+++ b/Tests/ResolverTests/ResolverInjectedTests.swift
@@ -35,6 +35,23 @@ class LazyInjectedViewController {
     @LazyInjected var service: XYZService
 }
 
+class WeakInjectedHolder {
+    @Injected var service: ABCService
+}
+
+class WeakInjectedNotHolder {
+    @WeakInjected var service: ABCService?
+}
+
+class LazyWeakInjectedViewController {
+    let name = "LazyWeakInjectedViewController"
+    @Injected var presenter: LazyWeakInjectedPresenter
+}
+
+class LazyWeakInjectedPresenter {
+    @LazyWeakInjected var viewController: LazyWeakInjectedViewController?
+}
+
 class OptionalInjectedViewController {
     @OptionalInjected var service: XYZService?
     @OptionalInjected var notRegistered: NotRegistered?
@@ -50,6 +67,8 @@ class ResolverInjectedTests: XCTestCase {
 
         Resolver.main.register { XYZSessionService() }
         Resolver.main.register { XYZService(Resolver.main.optional()) }
+        
+        Resolver.main.register { ABCService() }.scope(Resolver.shared)
 
         Resolver.main.register(name: "fred") { XYZNameService("fred") }
         Resolver.main.register(name: "barney") { XYZNameService("barney") }
@@ -92,6 +111,27 @@ class ResolverInjectedTests: XCTestCase {
         XCTAssertNotNil(vc.service.session)
         XCTAssert(!vc.$service.isEmpty)
     }
+    
+    func testWeakInjection() {
+        var vcHolder: WeakInjectedHolder? = WeakInjectedHolder()
+        let vcWeak = WeakInjectedNotHolder()
+        XCTAssertNotNil(vcWeak.service?.name)
+        vcHolder = nil
+        XCTAssertNil(vcWeak.service)
+    }
+    
+    func testLazyWeakInjection() {
+        Resolver.main.register { LazyWeakInjectedViewController() }.scope(Resolver.shared)
+        Resolver.main.register { LazyWeakInjectedPresenter() }.scope(Resolver.shared)
+        //
+        var vc: LazyWeakInjectedViewController? = Resolver.main.resolve(LazyWeakInjectedViewController.self)
+        let presenter = Resolver.main.resolve(LazyWeakInjectedPresenter.self)
+        XCTAssert(presenter.$viewController.isEmpty)
+        XCTAssertNotNil(presenter.viewController?.name)
+        vc = nil
+        XCTAssertNil(presenter.viewController)
+    }
+
     
     func testOptionalInjection() {
         let vc = OptionalInjectedViewController()

--- a/Tests/ResolverTests/TestData.swift
+++ b/Tests/ResolverTests/TestData.swift
@@ -63,6 +63,10 @@ class XYZService {
     }
 }
 
+class ABCService {
+    var name: String { return "ABCService" }
+}
+
 class XYZGraphService {
     let session1: XYZSessionService?
     let session2: XYZSessionService?


### PR DESCRIPTION
# Why

First of all, I and @PierreCapo created a test project for repro.
You can see the changes between "before WeakInjected" and "after" here: https://github.com/tychota/viper-resolver/commit/b7b247011dd63c9046906c9b4c40b568538bbbbd#diff-763fc821ab52258095102a64e77428459905a1983027f61827a8b88aab1474d8

![image](https://user-images.githubusercontent.com/13785185/99430407-92d7e900-2909-11eb-9cb4-6c506568c151.png)

and 

![image](https://user-images.githubusercontent.com/13785185/99430478-adaa5d80-2909-11eb-8069-dfdfeb7d41b1.png)


# What

Please review commit by commit as the commits are separated nicely.

There are a few commits to this PR.

Actual code:
- https://github.com/hmlongco/Resolver/commit/ce35acbfe2033d6e9309831b9ce1645f4ba4be36

Tests:
- https://github.com/hmlongco/Resolver/commit/ded5c892c47efb602376a9f425b8d390c1928264

Docs:
- fix swift comments: https://github.com/hmlongco/Resolver/commit/50883c64fc37fdfc7b0408cf1a6c8db0a63bac2d
- improve markdown and fix typos in existing documentation: https://github.com/hmlongco/Resolver/commit/bc1c492d27ba644d040fac9f77cf71019d89461d
- add new docs (please improve my wording, I'm not a native): https://github.com/hmlongco/Resolver/commit/449515d99a9df9ff2f8e4b247c94f47c812238be

# Test plan

- new and existing tests pass ✅
- https://github.com/tychota/viper-resolver is leak free without and with WeakInjected
![image](https://user-images.githubusercontent.com/13785185/99431226-b8192700-290a-11eb-8d55-c401c24c80a6.png)

- the box (`WeakObject`) is really small so apart from pointer indirection it should have no effect on performance

![image](https://user-images.githubusercontent.com/13785185/99431316-d717b900-290a-11eb-8148-1dfdfcbaa658.png)
