### PR TITLE
Add ability to forward arguments

### DIFF
--- a/Sources/Resolver/Resolver.swift
+++ b/Sources/Resolver/Resolver.swift
@@ -362,11 +362,13 @@ extension Resolver {
         private var args: [String:Any?]
 
         public init(_ args: Any?) {
-            if let args = args as? [String:Any?] {
+            if let args = args as? Args {
+                self.args = args.args
+            } else if let args = args as? [String:Any?] {
                 self.args = args
             } else {
                 self.args = ["" : args]
-             }
+            }
         }
 
         #if swift(>=5.2)


### PR DESCRIPTION
Allows for forwarding arguments when there are multiple.

Example:
```
register { _, args in SomeViewController(viewModel: resolve(args: args)) }
register { _, args in SomeViewModel(arg1: args("arg1"), arg2: args("arg2")) }
```


Currently,
 - if passed via `args`, it will be wrapped (`["" : args]`)
 - if passed as `args()`, it will crash due to there being multiple arguments