### PR TITLE
Expose `rawValue` to allow `Hashable` and `Equatable` external conformances

### DIFF
--- a/Sources/Resolver/Resolver.swift
+++ b/Sources/Resolver/Resolver.swift
@@ -357,7 +357,7 @@ extension Resolver {
 
     /// Internal class used by Resolver for typed name space support.
     public struct Name: ExpressibleByStringLiteral {
-        let rawValue: String
+        public let rawValue: String
         public init(_ rawValue: String) {
             self.rawValue = rawValue
         }


### PR DESCRIPTION
Right now, there's no way to build objects like `[Resolver.Name: SomeObject]` in order to register collections of named dependencies because `Resolver.Name` does not conform to `Hashable`. As it is a very concrete need, instead of adding the conformance inside the library I see more convenient to just make `public` the `rawValue` so it is possible to debug names and make external new conformances.