### PR TITLE
Add `.container` scope

### DIFF
--- a/Documentation/Scopes.md
+++ b/Documentation/Scopes.md
@@ -62,6 +62,19 @@ ResolverScope.cached.reset()
 
 You can also add your own [custom caches](#custom) to Resolver.
 
+## Scope: Container<a name=container></a>
+
+The `container` scope will make a given object instance to be retained, by the `cache` of the `Resolver` instance used for registration. Once it's been resolved the first time, and any subsequent resolutions will return the initial instance, as long as the `Resolver` instance exists, or its cache is reset or released.
+
+This scope is commonly used in project setups where no `static` references are held to user defined `Resolver` intances, in order to grant service instances the same lifecycle as the container.  
+
+```swift
+resolver.register { XYZApplicationService() }
+    .scope(.container)
+```
+
+This effectively makes the object a `Singleton within the container`.
+
 ## Scope: Graph<a name=graph></a>
 
 This scope will reuse any object instances resolved during a given [resolution cycle](Cycle.md).

--- a/Sources/Resolver/Resolver.swift
+++ b/Sources/Resolver/Resolver.swift
@@ -64,7 +64,8 @@ public final class Resolver {
     /// Default scope applied when registering new objects.
     public static var defaultScope: ResolverScope = .graph
     
-    public let cache = ResolverScopeCache()
+    /// Internal scope cache used for .scope(.container)
+    public lazy var cache: ResolverScope = ResolverScopeCache()
 
     // MARK: - Lifecycle
 
@@ -560,7 +561,7 @@ public class ResolverScope: ResolverScopeType {
 
     /// All application scoped services exist for lifetime of the app. (e.g Singletons)
     public static let application = ResolverScopeCache()
-    /// Cached services exist for lifetime of the container or until the containr's cache is reset.  (e.g Singleton within the container)
+    /// Proxy to container's scope. Cache type depends on type supplied to container (default .cache)
     public static let container = ResolverScopeContainer()
     /// Cached services exist for lifetime of the app or until their cache is reset.
     public static let cached = ResolverScopeCache()
@@ -677,7 +678,7 @@ public final class ResolverScopeUnique: ResolverScope {
 
 }
 
-/// Cached services exist for lifetime of the container or until cache of the container is reset.
+/// Proxy to container's scope. Cache type depends on type supplied to container (default .cache)
 public final class ResolverScopeContainer: ResolverScope {
     
     public override init() {}

--- a/Tests/ResolverTests/ResolverScopeValueTests.swift
+++ b/Tests/ResolverTests/ResolverScopeValueTests.swift
@@ -107,4 +107,27 @@ class ResolverScopeValueTests: XCTestCase {
         }
     }
 
+    func testResolverScopeContainer() {
+        resolver.register { XYZValue() }.scope(.container)
+        let value1: XYZValue? = resolver.optional()
+        let value2: XYZValue? = resolver.optional()
+        XCTAssertNotNil(value1)
+        XCTAssertNotNil(value2)
+        if let s1 = value1, let s2 = value2 {
+            XCTAssert(s1.id == s2.id)
+        } else {
+            XCTFail("values not cached")
+        }
+        
+        if let containerCache = resolver.cache as? ResolverScopeCache {
+            let oldID = value1?.id ?? UUID()
+            // Reset and try again
+            containerCache.reset()
+            if let newService: XYZValue = resolver.optional() {
+                XCTAssert(newService.id != oldID)
+            } else {
+                XCTFail("newService not resolved")
+            }
+        }
+    }
 }


### PR DESCRIPTION
### Introduction

This PR introduces a new registration scope: `.container`.
Using this, services can now be registered as "Singleton within the container", with the added bonus of being able to reset the container specific cache any time.

### Motivation

Projects where containers are used without `static` reference , commonly face the need to register a service with "Singleton within the container" scope.
This is completely possible by using a user defined `ResolverScopeCache` instance during service registrations, provided that the user makes sure this instance has the same lifecycle as the container.

The goal is to make this common usecase easier to implement.

### Proposed solution

`Resolver` instances now have a new property:
```swift
public final class Resolver {
    // ...
    public let cache = ResolverScopeCache()
    // ...
}
```
So each instance has its own cache to be used for the desired scope.

This container specific cache instance is then accessed via a new `ResolverScope` type, that acts as a proxy.

The container specific caches can be reset, by the user any time. If we want to ditch this feature, we only need to reduce the visiblity of the `cache` property below public.

Usage:
```swift
func assemble(container: Resolver) {
    container.register {
        return MyService()
    }.scope(.container)
}
```

### Effect on API

The suggested solution is small and backward compatible.