### PR TITLE
Multi injection support

### DIFF
--- a/Sources/Resolver/Resolver.swift
+++ b/Sources/Resolver/Resolver.swift
@@ -120,9 +120,9 @@ public final class Resolver {
     /// - returns: ResolverOptions instance that allows further customization of registered Service.
     ///
     @discardableResult
-    public static func register<Service>(_ type: Service.Type = Service.self, name: Resolver.Name? = nil,
+    public static func register<Service>(_ type: Service.Type = Service.self, name: Resolver.Name? = nil, multi: Bool = false,
                                          factory: @escaping ResolverFactory<Service>) -> ResolverOptions<Service> {
-        return main.register(type, name: name, factory: factory)
+        return main.register(type, name: name, multi: multi, factory: factory)
     }
 
     /// Static shortcut function used to register a specific Service type and its instantiating factory method.
@@ -134,9 +134,9 @@ public final class Resolver {
     /// - returns: ResolverOptions instance that allows further customization of registered Service.
     ///
     @discardableResult
-    public static func register<Service>(_ type: Service.Type = Service.self, name: Resolver.Name? = nil,
+    public static func register<Service>(_ type: Service.Type = Service.self, name: Resolver.Name? = nil, multi: Bool = false,
                                          factory: @escaping ResolverFactoryResolver<Service>) -> ResolverOptions<Service> {
-        return main.register(type, name: name, factory: factory)
+        return main.register(type, name: name, multi: multi, factory: factory)
     }
 
     /// Static shortcut function used to register a specific Service type and its instantiating factory method with multiple argument support.
@@ -148,9 +148,9 @@ public final class Resolver {
     /// - returns: ResolverOptions instance that allows further customization of registered Service.
     ///
     @discardableResult
-    public static func register<Service>(_ type: Service.Type = Service.self, name: Resolver.Name? = nil,
+    public static func register<Service>(_ type: Service.Type = Service.self, name: Resolver.Name? = nil, multi: Bool = false,
                                          factory: @escaping ResolverFactoryArgumentsN<Service>) -> ResolverOptions<Service> {
-        return main.register(type, name: name, factory: factory)
+        return main.register(type, name: name, multi: multi, factory: factory)
     }
 
     /// Registers a specific Service type and its instantiating factory method.
@@ -162,7 +162,7 @@ public final class Resolver {
     /// - returns: ResolverOptions instance that allows further customization of registered Service.
     ///
     @discardableResult
-    public final func register<Service>(_ type: Service.Type = Service.self, name: Resolver.Name? = nil,
+    public final func register<Service>(_ type: Service.Type = Service.self, name: Resolver.Name? = nil, multi: Bool = false,
                                         factory: @escaping ResolverFactory<Service>) -> ResolverOptions<Service> {
         lock.lock()
         defer { lock.unlock() }
@@ -182,7 +182,7 @@ public final class Resolver {
     /// - returns: ResolverOptions instance that allows further customization of registered Service.
     ///
     @discardableResult
-    public final func register<Service>(_ type: Service.Type = Service.self, name: Resolver.Name? = nil,
+    public final func register<Service>(_ type: Service.Type = Service.self, name: Resolver.Name? = nil, multi: Bool = false,
                                         factory: @escaping ResolverFactoryResolver<Service>) -> ResolverOptions<Service> {
         lock.lock()
         defer { lock.unlock() }
@@ -202,7 +202,7 @@ public final class Resolver {
     /// - returns: ResolverOptions instance that allows further customization of registered Service.
     ///
     @discardableResult
-    public final func register<Service>(_ type: Service.Type = Service.self, name: Resolver.Name? = nil,
+    public final func register<Service>(_ type: Service.Type = Service.self, name: Resolver.Name? = nil, multi: Bool = false,
                                         factory: @escaping ResolverFactoryArgumentsN<Service>) -> ResolverOptions<Service> {
         lock.lock()
         defer { lock.unlock() }

--- a/Sources/Resolver/Resolver.swift
+++ b/Sources/Resolver/Resolver.swift
@@ -414,6 +414,19 @@ extension Resolver {
 
 }
 
+/// Resolver Multi Injection Support
+extension Resolver {
+    
+    private struct MultiRegistration<Service> {
+        var registrations: [ResolverRegistration<Service>] = []
+        
+        mutating func add(_ registration: ResolverRegistration<Service>) {
+            registrations.append(registration)
+        }
+    }
+    
+}
+
 // Registration Internals
 
 private var registrationNeeded: Bool = true

--- a/Sources/Resolver/Resolver.swift
+++ b/Sources/Resolver/Resolver.swift
@@ -223,14 +223,7 @@ public final class Resolver {
     ///
     /// - returns: Instance of specified Service.
     public static func resolve<Service>(_ type: Service.Type = Service.self, name: Resolver.Name? = nil, args: Any? = nil) -> Service {
-        lock.lock()
-        defer { lock.unlock() }
-        registrationCheck()
-        if let registration = root.lookup(type, name: name),
-            let service = registration.scope.resolve(resolver: root, registration: registration, args: args) {
-            return service
-        }
-        fatalError("RESOLVER: '\(Service.self):\(name?.rawValue ?? "NONAME")' not resolved. To disambiguate optionals use resolver.optional().")
+        return main.resolve(type, name: name, args: args)
     }
 
     /// Resolves and returns an instance of the given Service type from the current registry or from its
@@ -262,14 +255,7 @@ public final class Resolver {
     /// - returns: Instance of specified Service.
     ///
     public static func optional<Service>(_ type: Service.Type = Service.self, name: Resolver.Name? = nil, args: Any? = nil) -> Service? {
-        lock.lock()
-        defer { lock.unlock() }
-        registrationCheck()
-        if let registration = root.lookup(type, name: name),
-            let service = registration.scope.resolve(resolver: root, registration: registration, args: args) {
-            return service
-        }
-        return nil
+        return main.optional(type, name: name, args: args)
     }
 
     /// Resolves and returns an optional instance of the given Service type from the current registry or

--- a/Sources/Resolver/Resolver.swift
+++ b/Sources/Resolver/Resolver.swift
@@ -919,7 +919,11 @@ public extension UIViewController {
         self.name = name
         self.container = container
     }
-
+    public var isEmpty: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return services == nil || services.isEmpty
+    }
     public var wrappedValue: [Service] {
         mutating get {
             lock.lock()

--- a/Tests/ResolverTests/ResolverBasicTests.swift
+++ b/Tests/ResolverTests/ResolverBasicTests.swift
@@ -110,4 +110,10 @@ class ResolverBasicTests: XCTestCase {
         XCTAssertNil(session)
     }
 
+    func testMultiRegistrationAndExplicitResolution() {
+        resolver.register(multi: true) { XYZSessionService() as XYZSessionProtocol }
+        resolver.register(multi: true) { XYZSessionService2() as XYZSessionProtocol }
+        let services: [XYZSessionProtocol] = resolver.multiResolve()
+        XCTAssert(services.count == 2)
+    }
 }

--- a/Tests/ResolverTests/ResolverInjectedTests.swift
+++ b/Tests/ResolverTests/ResolverInjectedTests.swift
@@ -55,6 +55,10 @@ class OptionalInjectedViewController {
     @OptionalInjected var notRegistered: NotRegistered?
 }
 
+class MultiInjectionViewController {
+    @MultiInjected var services: [XYZSessionProtocol]
+}
+
 protocol ReturnsSomething: AnyObject {
     func returnSomething() -> Bool
 }
@@ -92,6 +96,9 @@ class ResolverInjectedTests: XCTestCase {
         }
         
         Resolver.custom.register { XYZNameService("custom") }
+        
+        Resolver.main.register(multi: true) { XYZSessionService() as XYZSessionProtocol }
+        Resolver.main.register(multi: true) { XYZSessionService2() as XYZSessionProtocol }
     }
 
     override func tearDown() {
@@ -169,6 +176,11 @@ class ResolverInjectedTests: XCTestCase {
         XCTAssertNil(vc.notRegistered)
         vc.service = nil
         XCTAssertNil(vc.service)
+    }
+    
+    func testMultiInjectionViewController() {
+        let vc = MultiInjectionViewController()
+        XCTAssert(vc.services.count == 2)
     }
 }
 

--- a/Tests/ResolverTests/TestData.swift
+++ b/Tests/ResolverTests/TestData.swift
@@ -81,6 +81,11 @@ class XYZSessionService: XYZSessionProtocol {
     var name: String = "XYZSessionService"
 }
 
+class XYZSessionService2: XYZSessionProtocol {
+    let id = UUID()
+    var name: String = "XYZSessionService2"
+}
+
 class XYZNameService {
     let id = UUID()
     var name: String


### PR DESCRIPTION
## Introduction
After working with this library for a while, I noticed a shortcoming in it: _Multi Injection_
Suppose we need an injectable array of a specific type, If this dependency is already registered somewhere as an array once, everything will work fine. But what if we want the elements of this array to be registered in different parts of the code? 

## Explain the scenario
In this scenario we have an injectable array of interceptors in the `NetworkManager` class which is defined in our network layer:
```
public protocol Interceptor {
  func intercept(_ request: Request) -> Response
}

public class NetworkManager {
 public var interceptors: [Interceptor]
}
```
**We need to register various interceptors in different modules and we expect these interceptors to be injected as an array to our `NetworkManager`**

```
Resolver.register(multi: true) { SetAuthHeaderInterceptor() as Interceptor }
Resolver.register(multi: true) { ActivityIndicatorInterceptor() as Interceptor }.scope(.application)

public class NetworkManager {
 @MultiInjected public var interceptors: [Interceptor]
}

```

> In such a case we should tell the DI to register our Service with a different strategy. 

Let me continue in the code...
