### PR TITLE
ResolverRegistration - for a dependency resolution use a resolver with which the registration was created

### DIFF
--- a/Sources/Resolver/Resolver.swift
+++ b/Sources/Resolver/Resolver.swift
@@ -570,7 +570,7 @@ public final class ResolverRegistration<Service> {
 
     /// Called by Resolver containers to resolve a registration. Depending on scope may return a previously cached instance.
     public final func resolve(resolver: Resolver, args: Any?) -> Service? {
-        return scope.resolve(registration: self, resolver: resolver, args: args)
+        return scope.resolve(registration: self, resolver: self.resolver ?? resolver, args: args)
     }
     
     /// Called by Resolver scopes to instantiate a new instance of a service.


### PR DESCRIPTION
Hi there

Hope you are doing well and thank you for your effort

## I'm submitting a

- [x] bug report
- [ ] feature request

## Use case

I use nested containers to be able to reinitialize some services e.g when log in/out 

## What is the current behavior

When I create a child container, register some services on it with the container scope and at some moment later clear a cache on it - actually nothing to clear, because the services are in the main resolver's cache

## What is the expected behavior?

When a service is registered on a child container with the container scope - it's written in it's cache, not in the main one