### PR TITLE
Add support for watchOS in podspec

### DIFF
--- a/Resolver.podspec
+++ b/Resolver.podspec
@@ -14,6 +14,9 @@ Pod::Spec.new do |s|
 
   s.tvos.deployment_target = "11.0"
   s.tvos.framework  = 'UIKit'
+  
+  s.watchos.deployment_target = "4.0"
+  s.watchos.framework  = 'SwiftUI'
 
   s.osx.deployment_target = "10.15"
   s.osx.framework  = 'AppKit'


### PR DESCRIPTION
Back in 2019 (https://github.com/hmlongco/Resolver/commit/0a643cbf91955b2b2156db34237a005168d24d4e) support for macOS, tvOS and watchOS were added in the `Package.swift` file. Unfortunately, watchOS is missing in the `Resolver.podspec` file which makes it impossible to use Resolver in a project for watchOS.

This PR adds the required watchOS deployment target for it to work correctly. watchOS 4.0 matches iOS 11.0. It could also be set to 6.0 to match the SPM definition.